### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,99 @@
+name: Bug Report
+description: Create a report if something doesn't work quite right.
+title: ""
+labels: ["bug"]
+# assignees:
+#   - 
+body:
+
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Code and environment checks 
+      options:
+      - label: I am using the current [`master`](https://github.com/PyPSA/pypsa-usa/tree/master) branch
+        required: true
+      - label: I am running on an up-to-date [`pypsa-usa` environment](https://github.com/PyPSA/pypsa-usa/blob/master/workflow/envs/environment.yaml). Update via `conda env update -f envs/environment.yaml`
+        required: true
+
+  - type: textarea
+    attributes:
+      label: The Issue
+      description: Provide a concise description of what the bug is
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Add a minimal example/command for reproducing the bug
+      placeholder: |
+        1. Running this command...
+        2. With this config.yaml file data...
+        3. I get an error in this rule...
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: false
+
+  - type: textarea
+    id: error
+    attributes:
+      label: Error Message
+      description: |
+        If applicable, paste any terminal output to help illustrating your problem. 
+        In some cases it may also be useful to share your list of installed packages: `conda list` 
+        This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false
+
+  # - type: dropdown
+  #   id: os
+  #   attributes:
+  #     label: Operating System
+  #     description: What operating system are you running?
+  #     options:
+  #       - Linux
+  #       - MacOS
+  #       - Windows
+  #   validations:
+  #     required: true
+
+  # - type: input
+  #   id: version
+  #   attributes:
+  #     label: What version of PyPSA-USA are you running? 
+  #   validations:
+  #     required: true
+
+  # - type: textarea
+  #   id: solution
+  #   attributes:
+  #     label: Possible Solution
+  #     description: Do you have an idea on how to fix the issue?
+  #   validations:
+  #     required: false
+
+  - type: textarea
+    id: other
+    attributes:
+      label: Anything else?
+      description: |
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+
+  # - type: checkboxes
+  #   id: terms
+  #   attributes:
+  #     label: Code of Conduct
+  #     description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com)
+  #     options:
+  #       - label: I agree to follow this project's Code of Conduct
+  #         required: true

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -1,0 +1,53 @@
+name: Documentation
+description: Issues relating to documentation of PyPSA-USA
+title: ""
+labels: ["documentation"]
+body:
+
+- type: dropdown
+  id: issuetype
+  attributes:
+    label: Type of documentation issue
+    multiple: true
+    options:
+      - Missing Information
+      - Incorect Information
+      - Typo
+      - Other
+  validations:
+    required: true
+
+- type: textarea
+  id: description
+  attributes:
+    label: Issue Description
+    description: Detailed description of the documentation issue
+    placeholder: |
+      ie. There is no data source attached to the a `retrieve_data` rule 
+  validations:
+    required: true
+
+- type: textarea
+  id: current
+  attributes:
+    label: Link to existing documentation
+    description: If applicable, provide the link to the current documentation location
+  validations:
+    required: false
+
+- type: textarea
+  id: solution
+  attributes:
+    label: Suggested Update
+    description: Do you have an idea on how to update the documention?
+  validations:
+    required: false
+
+- type: textarea
+  id: other
+  attributes:
+    label: Additional Info
+    description: |
+      Please provide any additional information to help fix this documentation issue
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Ideas to improve PyPSA-USA
+title: ""
+labels: ["enhancement"]
+body:
+
+- type: textarea
+  id: request
+  attributes:
+    label: Feature Request
+    description: Detailed description the suggested improvement. Please provide context why the feature would be useful. 
+  validations:
+    required: true
+
+# - type: input
+#   id: bug
+#   attributes:
+#     label: Is your feature related to a bug?
+#     description: If applicable, refer to a an existing bug using the `#bugid` keyword
+#     placeholder: "#bugid 10"
+#   validations:
+#     required: false
+
+- type: textarea
+  id: solution
+  attributes:
+    label: Suggested Solution
+    description: Do you have an idea on how to implement the idea? Please include any references you already have. 
+  validations:
+    required: false
+
+- type: textarea
+  id: other
+  attributes:
+    label: Additional Info
+    description: |
+      Please provide any additional information or resources that will help us implement the idea.
+  validations:
+    required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+Closes # (if applicable).
+
+## Changes proposed in this Pull Request
+<!--- Describe your changes in detail -->
+
+## Checklist
+
+- [ ] I tested my contribution locally and it seems to work fine.
+- [ ] Code and workflow changes are sufficiently documented.
+- [ ] Changed dependencies are added to `envs/environment.yaml`.
+- [ ] Changes in configuration options are added in all of `config.default.yaml`.
+- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
+- [ ] A release note `doc/release_notes.rst` is added.


### PR DESCRIPTION
In this PR I have added: 

- A pull request template
- A Bug Report issue template 
- A Feature Request issue template 
- A Documentation issue template 

These templates are based off of the PyPSA-Eur ones. However, the issue templates have been updated to be `*.yaml` files to allow web form fields. 