### PR TITLE
revert brp to retain snapshots in config file

### DIFF
--- a/workflow/scripts/build_renewable_profiles.py
+++ b/workflow/scripts/build_renewable_profiles.py
@@ -225,20 +225,9 @@ if __name__ == "__main__":
     else:
         client = None
 
-    snapshot_config = snakemake.config["snapshots"]
-    sns_start = pd.to_datetime(snapshot_config["start"] + " 08:00:00")
-    sns_end = pd.to_datetime(snapshot_config["end"] + " 06:00:00")
-    sns_inclusive = snapshot_config["inclusive"]
-    sns = (
-        pd.date_range(
-            freq="h",
-            start=sns_start,
-            end=sns_end,
-            inclusive=sns_inclusive,
-        ),
-    )
-
-    cutout = atlite.Cutout(snakemake.input.cutout).sel(time=sns[0])
+    sns = pd.date_range(freq="h", **snakemake.config["snapshots"])
+    cutout = atlite.Cutout(snakemake.input.cutout).sel(time=sns)
+    
     regions = gpd.read_file(snakemake.input.regions)
     assert not regions.empty, (
         f"List of regions in {snakemake.input.regions} is empty, please "

--- a/workflow/scripts/build_renewable_profiles.py
+++ b/workflow/scripts/build_renewable_profiles.py
@@ -227,7 +227,7 @@ if __name__ == "__main__":
 
     sns = pd.date_range(freq="h", **snakemake.config["snapshots"])
     cutout = atlite.Cutout(snakemake.input.cutout).sel(time=sns)
-    
+
     regions = gpd.read_file(snakemake.input.regions)
     assert not regions.empty, (
         f"List of regions in {snakemake.input.regions} is empty, please "


### PR DESCRIPTION
reverts change made in #187 that changed the snapshots overwhich build_renewable_profiles was run. Previous implementation would try to build profiles outside the period which the cutout had data for.



## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
