### PR TITLE
Fixes `config.api.yaml` not being tracked by `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ dconf
 *.DS_Store
 *.dot
 *config.yaml
-*config.api.yaml
+workflow/config/config.api.yaml
 *.tar.gz
 
 

--- a/workflow/config/config.api.yaml
+++ b/workflow/config/config.api.yaml
@@ -1,0 +1,4 @@
+# holds user api keys
+
+api:
+  eia: 

--- a/workflow/config/config.api.yaml
+++ b/workflow/config/config.api.yaml
@@ -1,4 +1,4 @@
 # holds user api keys
 
 api:
-  eia: 'kcPPFTqXNLMU3Lrl9RXCzb2mNnGKZbwxhm5I6iYF'
+  eia:

--- a/workflow/config/config.api.yaml
+++ b/workflow/config/config.api.yaml
@@ -1,4 +1,0 @@
-# holds user api keys
-
-api:
-  eia:

--- a/workflow/config/config.api.yaml
+++ b/workflow/config/config.api.yaml
@@ -1,4 +1,4 @@
 # holds user api keys
 
 api:
-  eia: 
+  eia:


### PR DESCRIPTION
## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

Fixes the `config.api.yaml` file not being tracked by the `.gitignore`. For reference, I followed the suggestion in [this stack overflow thread](https://stackoverflow.com/a/64206592) to fix the issue! :) 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
