### PR TITLE
Switch Emission Accounting to PyPSA.Statistics

### DIFF
--- a/workflow/scripts/plot_statistics.py
+++ b/workflow/scripts/plot_statistics.py
@@ -135,14 +135,8 @@ def plot_accumulated_emissions_tech_html(
     # get data
 
     emissions = get_tech_emissions_timeseries(n).cumsum().mul(1e-6)  # T -> MT
-    emissions = emissions[
-        [
-            x
-            for x in n.carriers[n.carriers.co2_emissions > 0].index
-            if x in emissions.columns
-        ]
-    ]
-    emissions = emissions.rename(columns=n.carriers.nice_name)
+    zeros = emissions.columns[(np.abs(emissions) < 1e-7).all()]
+    emissions = emissions.drop(columns=zeros)
 
     # plot
 
@@ -172,14 +166,8 @@ def plot_hourly_emissions_html(n: pypsa.Network, save: str, **wildcards) -> None
     # get data
 
     emissions = get_tech_emissions_timeseries(n).mul(1e-6)  # T -> MT
-    emissions = emissions[
-        [
-            x
-            for x in n.carriers[n.carriers.co2_emissions > 0].index
-            if x in emissions.columns
-        ]
-    ]
-    emissions = emissions.rename(columns=n.carriers.nice_name)
+    zeros = emissions.columns[(np.abs(emissions) < 1e-7).all()]
+    emissions = emissions.drop(columns=zeros)
 
     # plot
 
@@ -684,14 +672,8 @@ def plot_hourly_emissions(n: pypsa.Network, save: str, **wildcards) -> None:
     # get data
 
     emissions = get_tech_emissions_timeseries(n).mul(1e-6)  # T -> MT
-    emissions = emissions[
-        [
-            x
-            for x in n.carriers[n.carriers.co2_emissions > 0].index
-            if x in emissions.columns
-        ]
-    ]
-    emissions = emissions.rename(columns=n.carriers.nice_name)
+    zeros = emissions.columns[(np.abs(emissions) < 1e-7).all()]
+    emissions = emissions.drop(columns=zeros)
 
     # plot
     color_palette = get_color_palette(n)
@@ -721,14 +703,8 @@ def plot_accumulated_emissions_tech(n: pypsa.Network, save: str, **wildcards) ->
     # get data
 
     emissions = get_tech_emissions_timeseries(n).cumsum().mul(1e-6)  # T -> MT
-    emissions = emissions[
-        [
-            x
-            for x in n.carriers[n.carriers.co2_emissions > 0].index
-            if x in emissions.columns
-        ]
-    ]
-    emissions = emissions.rename(columns=n.carriers.nice_name)
+    zeros = emissions.columns[(np.abs(emissions) < 1e-7).all()]
+    emissions = emissions.drop(columns=zeros)
 
     # plot
 

--- a/workflow/scripts/summary.py
+++ b/workflow/scripts/summary.py
@@ -11,12 +11,51 @@ import pandas as pd
 import pypsa
 from _helpers import configure_logging
 
+from pypsa.statistics import StatisticsAccessor
+from pypsa.statistics import get_bus_and_carrier, get_name_bus_and_carrier
+
 logger = logging.getLogger(__name__)
 
 
 ###
 # ENERGY SUPLPY
 ###
+
+
+def get_primary_energy_use(n: pypsa.Network) -> pd.DataFrame:
+    """Gets timeseries primary energy use by bus and carrier"""
+
+    link_energy_use = (
+        StatisticsAccessor(n)
+        .withdrawal(
+            comps=["Link", "Store", "StorageUnit"],
+            aggregate_time=False,
+            groupby=get_bus_and_carrier,
+        )
+        .droplevel("component")
+    )
+
+    gen_dispatch = (
+        StatisticsAccessor(n)
+        .supply(
+            aggregate_time=False,
+            comps=["Generator"],
+            groupby=pypsa.statistics.get_name_bus_and_carrier,
+        )
+        .droplevel("component")
+    )
+    gen_eff = n.get_switchable_as_dense("Generator", "efficiency")
+
+    gen_energy_use = gen_dispatch.T.mul(1 / gen_eff, axis=0, level="name").T.droplevel(
+        "name"
+    )
+
+    return (
+        pd.concat([gen_energy_use, link_energy_use])
+        .reset_index()
+        .groupby(["bus", "carrier"])
+        .sum()
+    )
 
 
 def get_energy_total(n: pypsa.Network):
@@ -259,51 +298,32 @@ def get_generator_marginal_costs(
 ###
 
 
+def get_node_carrier_emissions_timeseries(n: pypsa.Network) -> pd.DataFrame:
+    """Gets timeseries emissions by bus and carrier"""
+
+    energy = get_primary_energy_use(n)
+    co2 = (
+        n.carriers[["nice_name", "co2_emissions"]]
+        .reset_index()
+        .set_index("nice_name")[["co2_emissions"]]
+        .squeeze()
+    )
+    return energy.mul(co2, level="carrier", axis=0)
+
+
 def get_node_emissions_timeseries(n: pypsa.Network) -> pd.DataFrame:
     """
     Gets timeseries emissions per node.
     """
 
-    totals = []
-    for c in n.iterate_components(n.one_port_components | n.branch_components):
-        if c.name in ("Generator"):
-
-            # get time series efficiency
-            eff = n.get_switchable_as_dense("Generator", "efficiency")
-
-            co2_factor = (
-                c.df.carrier.map(n.carriers.co2_emissions)
-                .fillna(0)
-                .infer_objects(copy=False)
-            )
-
-            totals.append(
-                (
-                    c.pnl.p.mul(1 / eff)
-                    .mul(co2_factor)
-                    .T.groupby(n.generators.bus)
-                    .sum()
-                    .T
-                ),
-            )
-        elif c.name == "Link":  # efficiency taken into account by using p0
-
-            co2_factor = (
-                c.df.carrier.map(n.carriers.co2_emissions)
-                .fillna(0)
-                .infer_objects(copy=False)
-            )
-
-            totals.append(
-                (
-                    c.pnl.p0.mul(co2_factor)
-                    .T.groupby(n.links.bus0)
-                    .sum()
-                    .rename_axis(index={"bus0": "bus"})
-                    .T
-                ),
-            )
-    return pd.concat(totals, axis=1)
+    return (
+        get_node_carrier_emissions_timeseries(n)
+        .droplevel("carrier")
+        .reset_index()
+        .groupby("bus")
+        .sum()
+        .T
+    )
 
 
 def get_tech_emissions_timeseries(n: pypsa.Network) -> pd.DataFrame:
@@ -311,40 +331,14 @@ def get_tech_emissions_timeseries(n: pypsa.Network) -> pd.DataFrame:
     Gets timeseries emissions per technology.
     """
 
-    totals = []
-    for c in n.iterate_components(n.one_port_components | n.branch_components):
-        if c.name in ("Generator"):
-
-            # get time series efficiency
-            eff = c.pnl.efficiency
-            eff_static = {}
-            for gen in [x for x in c.df.index if x not in eff.columns]:
-                eff_static[gen] = [c.df.at[gen, "efficiency"]] * len(eff)
-            eff = pd.concat([eff, pd.DataFrame(eff_static, index=eff.index)], axis=1)
-
-            co2_factor = c.df.carrier.map(n.carriers.co2_emissions).fillna(0)
-
-            totals.append(
-                (
-                    c.pnl.p.mul(1 / eff)
-                    .mul(co2_factor)
-                    .T.groupby(n.generators.carrier)
-                    .sum()
-                    .T
-                ),
-            )
-        elif c.name == "Link":  # efficiency taken into account by using p0
-
-            co2_factor = (
-                c.df.carrier.map(n.carriers.co2_emissions)
-                .fillna(0)
-                .infer_objects(copy=False)
-            )
-
-            totals.append(
-                (c.pnl.p0.mul(co2_factor).T.groupby(n.links.carrier).sum().T),
-            )
-    return pd.concat(totals, axis=1)
+    return (
+        get_node_carrier_emissions_timeseries(n)
+        .droplevel("bus")
+        .reset_index()
+        .groupby("carrier")
+        .sum()
+        .T
+    )
 
 
 if __name__ == "__main__":

--- a/workflow/scripts/summary.py
+++ b/workflow/scripts/summary.py
@@ -23,7 +23,9 @@ logger = logging.getLogger(__name__)
 
 
 def get_primary_energy_use(n: pypsa.Network) -> pd.DataFrame:
-    """Gets timeseries primary energy use by bus and carrier"""
+    """
+    Gets timeseries primary energy use by bus and carrier.
+    """
 
     link_energy_use = (
         StatisticsAccessor(n)
@@ -47,7 +49,7 @@ def get_primary_energy_use(n: pypsa.Network) -> pd.DataFrame:
     gen_eff = n.get_switchable_as_dense("Generator", "efficiency")
 
     gen_energy_use = gen_dispatch.T.mul(1 / gen_eff, axis=0, level="name").T.droplevel(
-        "name"
+        "name",
     )
 
     return (
@@ -299,7 +301,9 @@ def get_generator_marginal_costs(
 
 
 def get_node_carrier_emissions_timeseries(n: pypsa.Network) -> pd.DataFrame:
-    """Gets timeseries emissions by bus and carrier"""
+    """
+    Gets timeseries emissions by bus and carrier.
+    """
 
     energy = get_primary_energy_use(n)
     co2 = (


### PR DESCRIPTION
## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

In this PR I have switched emissions accounting to use the `pypsa.statistics.StatisticsAccessor` methods. Specifically I have: 
1. Added a new function to find primary energy consumption called `get_primary_energy_use`
2. Added a new function to find generator/node/carrier emissions called `get_node_carrier_emissions_timeseries`
3. Modified the `get_node_emissions_timeseries` and `get_technology_emissions_timeseries` functions to use the `get_node_carrier_emissions_timeseries`

While two new functions are added, overall, the logic is much simpler as we are not looping over all the different components to find primary energy use. 

I did a qualitative check on the graphs to make sure the results have not changed. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
