### PR TITLE
And End Use Load Profile Demand 

### DIFF
--- a/workflow/rules/retrieve.smk
+++ b/workflow/rules/retrieve.smk
@@ -134,54 +134,59 @@ rule retrieve_eia_data:
 
 
 RESSTOCK_FILES = [
-        "mobile_home",
-        "multi-family_with_2_-_4_units",
-        "multi-family_with_5plus_units",
-        "single-family_attached",
-        "single-family_detached",
-    ]
+    "mobile_home",
+    "multi-family_with_2_-_4_units",
+    "multi-family_with_5plus_units",
+    "single-family_attached",
+    "single-family_detached",
+]
 
 COMSTOCK_FILES = [
-        "fullservicerestaurant",
-        "hospital",
-        "largehotel",
-        "largeoffice",
-        "mediumoffice",
-        "outpatient",
-        "primaryschool",
-        "quickservicerestaurant",
-        "retailstandalone",
-        "retailstripmall",
-        "secondaryschool",
-        "smallhotel",
-        "smalloffice",
-        "warehouse",
-    ]
+    "fullservicerestaurant",
+    "hospital",
+    "largehotel",
+    "largeoffice",
+    "mediumoffice",
+    "outpatient",
+    "primaryschool",
+    "quickservicerestaurant",
+    "retailstandalone",
+    "retailstripmall",
+    "secondaryschool",
+    "smallhotel",
+    "smalloffice",
+    "warehouse",
+]
 
-# need seperate rules cause cant access params in output 
+# need seperate rules cause cant access params in output
 # https://github.com/snakemake/snakemake/issues/1122
 
+
 rule retrieve_res_eulp:
-    log: "logs/retrieve/retrieve_res_eulp/{state}.log",
+    log:
+        "logs/retrieve/retrieve_res_eulp/{state}.log",
     params:
-        stock = "res",
-        profiles = RESSTOCK_FILES,
-        save_dir = DATA + "eulp/res/"
+        stock="res",
+        profiles=RESSTOCK_FILES,
+        save_dir=DATA + "eulp/res/",
     output:
-        expand(DATA + "eulp/res/{{state}}/{profile}.csv", profile=RESSTOCK_FILES)
-    script: 
+        expand(DATA + "eulp/res/{{state}}/{profile}.csv", profile=RESSTOCK_FILES),
+    script:
         "../scripts/retrieve_eulp.py"
 
+
 rule retrieve_com_eulp:
-    log: "logs/retrieve/retrieve_com_eulp/{state}.log",
+    log:
+        "logs/retrieve/retrieve_com_eulp/{state}.log",
     params:
-        stock = "com",
-        profiles = COMSTOCK_FILES,
-        save_dir = DATA + "eulp/com/"
+        stock="com",
+        profiles=COMSTOCK_FILES,
+        save_dir=DATA + "eulp/com/",
     output:
-        expand(DATA + "eulp/com/{{state}}/{profile}.csv", profile=COMSTOCK_FILES)
-    script: 
+        expand(DATA + "eulp/com/{{state}}/{profile}.csv", profile=COMSTOCK_FILES),
+    script:
         "../scripts/retrieve_eulp.py"
+
 
 rule retrieve_ship_raster:
     input:

--- a/workflow/rules/retrieve.smk
+++ b/workflow/rules/retrieve.smk
@@ -133,6 +133,56 @@ rule retrieve_eia_data:
         "../scripts/retrieve_eia_data.py"
 
 
+RESSTOCK_FILES = [
+        "mobile_home",
+        "multi-family_with_2_-_4_units",
+        "multi-family_with_5plus_units",
+        "single-family_attached",
+        "single-family_detached",
+    ]
+
+COMSTOCK_FILES = [
+        "fullservicerestaurant",
+        "hospital",
+        "largehotel",
+        "largeoffice",
+        "mediumoffice",
+        "outpatient",
+        "primaryschool",
+        "quickservicerestaurant",
+        "retailstandalone",
+        "retailstripmall",
+        "secondaryschool",
+        "smallhotel",
+        "smalloffice",
+        "warehouse",
+    ]
+
+# need seperate rules cause cant access params in output 
+# https://github.com/snakemake/snakemake/issues/1122
+
+rule retrieve_res_eulp:
+    log: "logs/retrieve/retrieve_res_eulp/{state}.log",
+    params:
+        stock = "res",
+        profiles = RESSTOCK_FILES,
+        save_dir = DATA + "eulp/res/"
+    output:
+        expand(DATA + "eulp/res/{{state}}/{profile}.csv", profile=RESSTOCK_FILES)
+    script: 
+        "../scripts/retrieve_eulp.py"
+
+rule retrieve_com_eulp:
+    log: "logs/retrieve/retrieve_com_eulp/{state}.log",
+    params:
+        stock = "com",
+        profiles = COMSTOCK_FILES,
+        save_dir = DATA + "eulp/com/"
+    output:
+        expand(DATA + "eulp/com/{{state}}/{profile}.csv", profile=COMSTOCK_FILES)
+    script: 
+        "../scripts/retrieve_eulp.py"
+
 rule retrieve_ship_raster:
     input:
         HTTP.remote(

--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -43,7 +43,7 @@ from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import List
-from typing import Union
+from typing import Optional
 
 import constants as const
 import geopandas as gpd
@@ -64,6 +64,183 @@ from sklearn.neighbors import BallTree
 idx = pd.IndexSlice
 
 logger = logging.getLogger(__name__)
+
+
+class Eulp:
+    """Reads in an end use load profile from https://data.openei.org/submissions/4520"""
+
+    _elec_group = [
+        # res and com
+        "out.electricity.lighting_exterior.energy_consumption.kwh",  #
+        "out.electricity.lighting_interior.energy_consumption.kwh",  #
+        "out.electricity.water_systems.energy_consumption.kwh",
+        # res only
+        "out.electricity.bath_fan.energy_consumption.kwh",
+        "out.electricity.ceiling_fan.energy_consumption.kwh",  #
+        "out.electricity.clothes_dryer.energy_consumption.kwh",  #
+        "out.electricity.clothes_washer.energy_consumption.kwh",  #
+        "out.electricity.range_oven.energy_consumption.kwh",
+        "out.electricity.dishwasher.energy_consumption.kwh",  #
+        "out.electricity.ext_holiday_light.energy_consumption.kwh",
+        "out.electricity.extra_refrigerator.energy_consumption.kwh",
+        "out.electricity.freezer.energy_consumption.kwh",  #
+        "out.electricity.lighting_garage.energy_consumption.kwh",  #
+        "out.electricity.mech_vent.energy_consumption.kwh",  #
+        "out.electricity.permanent_spa_pump.energy_consumption.kwh",  #
+        "out.electricity.hot_tub_pump.energy_consumption.kwh",
+        "out.electricity.house_fan.energy_consumption.kwh",
+        "out.electricity.plug_loads.energy_consumption.kwh",  #
+        "out.electricity.pool_pump.energy_consumption.kwh",  #
+        "out.electricity.pv.energy_consumption.kwh",  #
+        "out.electricity.range_fan.energy_consumption.kwh",
+        "out.electricity.recirc_pump.energy_consumption.kwh",
+        "out.electricity.refrigerator.energy_consumption.kwh",  #
+        "out.electricity.vehicle.energy_consumption.kwh",
+        "out.electricity.well_pump.energy_consumption.kwh",  #
+        # com only
+        "out.electricity.fans.energy_consumption.kwh",
+        "out.electricity.interior_equipment.energy_consumption.kwh",
+        "out.electricity.pumps.energy_consumption.kwh",
+    ]
+
+    _heat_group = [
+        # res and com
+        "out.electricity.heating.energy_consumption.kwh",  #
+        "out.natural_gas.heating.energy_consumption.kwh",
+        "out.natural_gas.water_systems.energy_consumption.kwh",
+        "out.natural_gas.hot_water.energy_consumption.kwh",  #
+        # res only
+        "out.electricity.heating_fans_pumps.energy_consumption.kwh",  #
+        "out.electricity.heating_hp_bkup.energy_consumption.kwh",  #
+        "out.electricity.heating_hp_bkup_fa.energy_consumption.kwh",  #
+        "out.electricity.hot_water.energy_consumption.kwh",  #
+        "out.electricity.permanent_spa_heat.energy_consumption.kwh",  #
+        "out.electricity.pool_heater.energy_consumption.kwh",  #
+        "out.fuel_oil.heating.energy_consumption.kwh",  #
+        "out.fuel_oil.heating_hp_bkup.energy_consumption.kwh",  #
+        "out.fuel_oil.hot_water.energy_consumption.kwh",  #
+        "out.fuel_oil.total.energy_consumption.kwh",  #
+        "out.electricity.heating_supplement.energy_consumption.kwh",
+        "out.natural_gas.heating_hp_bkup.energy_consumption.kwh",  #
+        "out.electricity.fans_heating.energy_consumption.kwh",
+        "out.natural_gas.clothes_dryer.energy_consumption.kwh",  #
+        "out.natural_gas.cooking_range.energy_consumption.kwh",
+        "out.natural_gas.range_oven.energy_consumption.kwh",  #
+        "out.natural_gas.fireplace.energy_consumption.kwh",  #
+        "out.natural_gas.grill.energy_consumption.kwh",  #
+        "out.natural_gas.hot_tub_heater.energy_consumption.kwh",
+        "out.natural_gas.lighting.energy_consumption.kwh",  #
+        "out.natural_gas.permanent_spa_heat.energy_consumption.kwh",  #
+        "out.natural_gas.pool_heater.energy_consumption.kwh",  #
+        "out.natural_gas.permanent_spa_heat.energy_consumption.kwh",  #
+        "out.propane.clothes_dryer.energy_consumption.kwh",  #
+        "out.propane.cooking_range.energy_consumption.kwh",
+        "out.propane.heating.energy_consumption.kwh",  #
+        "out.propane.heating_hp_bkup.energy_consumption.kwh",  #
+        "out.propane.hot_water.energy_consumption.kwh",  #
+        "out.propane.range_oven.energy_consumption.kwh",  #
+        "out.propane.water_systems.energy_consumption.kwh",
+        "out.wood.heating.energy_consumption.kwh",
+        "out.electricity.hot_tub_heater.energy_consumption.kwh",
+        # com only
+        "out.other_fuel.heating.energy_consumption.kwh",
+    ]
+
+    _cool_group = [
+        # res and com
+        "out.electricity.cooling.energy_consumption.kwh",  #
+        # res only
+        "out.electricity.fans_cooling.energy_consumption.kwh",
+        "out.electricity.cooling_fans_pumps.energy_consumption.kwh",  #
+        # com only
+        "out.district_cooling.cooling.energy_consumption.kwh",
+        "out.electricity.heat_rejection.energy_consumption.kwh",
+        "out.electricity.refrigeration.energy_consumption.kwh",
+    ]
+
+    def __init__(
+        self, filepath: Optional[str] = None, df: Optional[pd.DataFrame] = None
+    ) -> None:
+        if filepath:
+            df = self.read_data(filepath)
+            df = self.aggregate_data(df)
+            self.data = self.resample_data(df)
+        elif isinstance(df, pd.DataFrame):
+            self.data = df
+            assert (self.data.columns == ["electricity", "heating", "cooling"]).all()
+        else:
+            raise TypeError(
+                f"missing 1 required positional argument: 'filepath' or 'df'"
+            )
+
+    def __add__(self, other):
+        if isinstance(other, Eulp):
+            return Eulp(df=self.data.add(other.data))
+        else:
+            raise TypeError()
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    def __str__(self):
+        return "Properties are 'data', 'electric', 'heating', 'cooling'"
+
+    def __repr__(self):
+        return f"\n{self.data.head(3)}\n\n from {self.data.index[0]} to {self.data.index[-1]}"
+
+    @property
+    def electric(self):
+        return self.data["electricity"]
+
+    @property
+    def heating(self):
+        return self.data["heating"]
+
+    @property
+    def cooling(self):
+        return self.data["heating"]
+
+    @classmethod
+    def read_data(self, filepath: str) -> pd.DataFrame:
+        df = pd.read_csv(filepath, engine="pyarrow", index_col="timestamp")
+        df.index = pd.to_datetime(df.index)
+        return df
+
+    @classmethod
+    def resample_data(self, df: pd.DataFrame, resample: str = "1h") -> pd.DataFrame:
+        if not isinstance(df.index, pd.DatetimeIndex):
+            df.index = pd.to_datetime(df.index)
+        return df.resample(resample).sum()
+
+    def aggregate_data(self, df: pd.DataFrame) -> pd.DataFrame:
+
+        def aggregate_sector(df: pd.DataFrame, columns: List[str]) -> pd.Series:
+            sector_columns = [x for x in columns if x in df.columns.to_list()]
+            return df[sector_columns].sum(axis=1)
+
+        dfs = []
+        sectors = {
+            "electricity": self._elec_group,
+            "heating": self._heat_group,
+            "cooling": self._cool_group,
+        }
+        for sector, sector_cols in sectors.items():
+            sector_load = aggregate_sector(df, sector_cols)
+            sector_load.name = sector
+            dfs.append(sector_load)
+
+        return pd.concat(dfs, axis=1).mul(1e-3)  # kwh -> MWh
+
+    def plot(
+        self, sectors: Optional[List[str] | str] = ["electricity", "heating", "cooling"]
+    ):
+
+        if isinstance(sectors, str):
+            sectors = [sectors]
+
+        df = self.data[sectors]
+
+        return df.plot(xlabel="", ylabel="MWh")
 
 
 def prepare_ads_demand(

--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -159,7 +159,9 @@ class Eulp:
     ]
 
     def __init__(
-        self, filepath: Optional[str] = None, df: Optional[pd.DataFrame] = None
+        self,
+        filepath: Optional[str] = None,
+        df: Optional[pd.DataFrame] = None,
     ) -> None:
         if filepath:
             df = self.read_data(filepath)
@@ -170,7 +172,7 @@ class Eulp:
             assert (self.data.columns == ["electricity", "heating", "cooling"]).all()
         else:
             raise TypeError(
-                f"missing 1 required positional argument: 'filepath' or 'df'"
+                f"missing 1 required positional argument: 'filepath' or 'df'",
             )
 
     def __add__(self, other):
@@ -214,7 +216,7 @@ class Eulp:
 
     def aggregate_data(self, df: pd.DataFrame) -> pd.DataFrame:
 
-        def aggregate_sector(df: pd.DataFrame, columns: List[str]) -> pd.Series:
+        def aggregate_sector(df: pd.DataFrame, columns: list[str]) -> pd.Series:
             sector_columns = [x for x in columns if x in df.columns.to_list()]
             return df[sector_columns].sum(axis=1)
 
@@ -232,7 +234,8 @@ class Eulp:
         return pd.concat(dfs, axis=1).mul(1e-3)  # kwh -> MWh
 
     def plot(
-        self, sectors: Optional[List[str] | str] = ["electricity", "heating", "cooling"]
+        self,
+        sectors: Optional[list[str] | str] = ["electricity", "heating", "cooling"],
     ):
 
         if isinstance(sectors, str):

--- a/workflow/scripts/retrieve_eulp.py
+++ b/workflow/scripts/retrieve_eulp.py
@@ -12,19 +12,27 @@ from typing import Optional, List
 import requests
 from pathlib import Path
 
+from _helpers import configure_logging
+import constants
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 class OediDownload:
     """Downlaods Oedi restock or comstock data at a state level"""
-    
+
     root = "https://oedi-data-lake.s3.amazonaws.com/nrel-pds-building-stock/end-use-load-profiles-for-us-building-stock/2024"
-    
+
     res_files = [
         "mobile_home",
         "multi-family_with_2_-_4_units",
         "multi-family_with_5plus_units",
         "single-family_attached",
-        "single-family_detached"
+        "single-family_detached",
     ]
-    
+
     com_files = [
         "fullservicerestaurant",
         "hospital",
@@ -39,80 +47,102 @@ class OediDownload:
         "secondaryschool",
         "smallhotel",
         "smalloffice",
-        "warehouse"
+        "warehouse",
     ]
-    
+
     def __init__(self, stock: str) -> None:
         assert stock in ["res", "com"]
         self.stock = stock
         self.release = 2 if self.stock == "res" else 1
-        
+
     def _get_html_folder(self, state: str, upgrade: Optional[int] = 0) -> str:
         """Gets html of folder"""
-        
+
         if self.stock == "res":
             data_folder = f"resstock_amy2018_release_{self.release}"
         elif self.stock == "com":
             data_folder = f"comstock_amy2018_release_{self.release}"
-        
+
         return f"{self.root}/{data_folder}/timeseries_aggregates/by_state/upgrade={upgrade}/state={state.upper()}"
-    
-    def _get_htmls(self, state: str, buildings: str | List[str], upgrade: int = 0) -> List[str]:
-        
+
+    def _get_htmls(
+        self, state: str, buildings: str | List[str], upgrade: int = 0
+    ) -> List[str]:
+
         folder = self._get_html_folder(state)
-        
+
         if isinstance(buildings, str):
             buildings = [buildings]
-        
+
         upgrade_padded = f"{upgrade:02d}"
-        
+
         htmls = []
         for building in buildings:
             htmls.append(f"{folder}/up{upgrade_padded}-{state.lower()}-{building}.csv")
-        
+
         return htmls
-    
+
     def _request_data(self, url: str, save: str) -> dict[str, dict | str]:
 
         response = requests.get(url)
         if response.status_code == 200:
+            logger.info(f"Writing {save}")
             with open(save, "wb") as f:
                 f.write(response.content)
         else:
             raise requests.ConnectionError(f"Status code {response.status_code}")
-    
+
     def _get_building_from_html(self, html: str, state: int) -> str:
         return html.split(f"-{state.lower()}-")[-1].split(".csv")[0]
-    
+
     def _create_save_dir(self, directory: str) -> None:
         path = Path(directory)
         if not path.exists():
             path.mkdir(parents=True, exist_ok=True)
-                
-    def download_data(self, state: str, buildings: Optional[str | List[str]] = None, upgrade: int = 0, directory: Optional[str] = None) -> None:
+
+    def download_data(
+        self,
+        state: str,
+        buildings: Optional[str | List[str]] = None,
+        upgrade: int = 0,
+        directory: Optional[str] = None,
+    ) -> None:
         """Public method to interface with"""
-        
+
         if not directory:
             directory = f"{state}"
         else:
             directory = f"{directory}/{state}"
-        
+
         self._create_save_dir(directory)
-        
+
         if not buildings:
             if self.stock == "res":
                 buildings = self.res_files
             elif self.stock == "com":
                 buildings = self.com_files
-        
+
         htmls = self._get_htmls(state, buildings)
-        
+
         for html in htmls:
             save_name = self._get_building_from_html(html, state)
             save_path = f"{directory}/{save_name}.csv"
             self._request_data(html, save_path)
-            
-        
 
-        
-        
+
+if __name__ == "__main__":
+
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake("retrieve_res_eulp", state="WA")
+    configure_logging(snakemake)
+
+    stock = snakemake.params.stock
+    state = snakemake.wildcards.state
+    buildings = snakemake.params.profiles
+    save_dir = snakemake.params.save_dir
+
+    oedi = OediDownload(stock)
+
+    oedi.download_data(state, buildings, 0, save_dir)

--- a/workflow/scripts/retrieve_eulp.py
+++ b/workflow/scripts/retrieve_eulp.py
@@ -1,9 +1,10 @@
-"""Module to download end use load profiles (eulp) for comstock and restock data
+"""
+Module to download end use load profiles (eulp) for comstock and restock data.
 
 Notes:
     - Downloaded at state level
     - Multisector 15-min load profiles for a year (ie. lots of data)
-    - Locked to 2018 Amy Weather data 
+    - Locked to 2018 Amy Weather data
     - https://data.openei.org/submissions/4520
 """
 
@@ -21,7 +22,9 @@ logger = logging.getLogger(__name__)
 
 
 class OediDownload:
-    """Downlaods Oedi restock or comstock data at a state level"""
+    """
+    Downlaods Oedi restock or comstock data at a state level.
+    """
 
     root = "https://oedi-data-lake.s3.amazonaws.com/nrel-pds-building-stock/end-use-load-profiles-for-us-building-stock/2024"
 
@@ -56,7 +59,9 @@ class OediDownload:
         self.release = 2 if self.stock == "res" else 1
 
     def _get_html_folder(self, state: str, upgrade: Optional[int] = 0) -> str:
-        """Gets html of folder"""
+        """
+        Gets html of folder.
+        """
 
         if self.stock == "res":
             data_folder = f"resstock_amy2018_release_{self.release}"
@@ -66,8 +71,11 @@ class OediDownload:
         return f"{self.root}/{data_folder}/timeseries_aggregates/by_state/upgrade={upgrade}/state={state.upper()}"
 
     def _get_htmls(
-        self, state: str, buildings: str | List[str], upgrade: int = 0
-    ) -> List[str]:
+        self,
+        state: str,
+        buildings: str | list[str],
+        upgrade: int = 0,
+    ) -> list[str]:
 
         folder = self._get_html_folder(state)
 
@@ -103,11 +111,13 @@ class OediDownload:
     def download_data(
         self,
         state: str,
-        buildings: Optional[str | List[str]] = None,
+        buildings: Optional[str | list[str]] = None,
         upgrade: int = 0,
         directory: Optional[str] = None,
     ) -> None:
-        """Public method to interface with"""
+        """
+        Public method to interface with.
+        """
 
         if not directory:
             directory = f"{state}"

--- a/workflow/scripts/retrieve_eulp.py
+++ b/workflow/scripts/retrieve_eulp.py
@@ -1,0 +1,118 @@
+"""Module to download end use load profiles (eulp) for comstock and restock data
+
+Notes:
+    - Downloaded at state level
+    - Multisector 15-min load profiles for a year (ie. lots of data)
+    - Locked to 2018 Amy Weather data 
+    - https://data.openei.org/submissions/4520
+"""
+
+import pandas as pd
+from typing import Optional, List
+import requests
+from pathlib import Path
+
+class OediDownload:
+    """Downlaods Oedi restock or comstock data at a state level"""
+    
+    root = "https://oedi-data-lake.s3.amazonaws.com/nrel-pds-building-stock/end-use-load-profiles-for-us-building-stock/2024"
+    
+    res_files = [
+        "mobile_home",
+        "multi-family_with_2_-_4_units",
+        "multi-family_with_5plus_units",
+        "single-family_attached",
+        "single-family_detached"
+    ]
+    
+    com_files = [
+        "fullservicerestaurant",
+        "hospital",
+        "largehotel",
+        "largeoffice",
+        "mediumoffice",
+        "outpatient",
+        "primaryschool",
+        "quickservicerestaurant",
+        "retailstandalone",
+        "retailstripmall",
+        "secondaryschool",
+        "smallhotel",
+        "smalloffice",
+        "warehouse"
+    ]
+    
+    def __init__(self, stock: str) -> None:
+        assert stock in ["res", "com"]
+        self.stock = stock
+        self.release = 2 if self.stock == "res" else 1
+        
+    def _get_html_folder(self, state: str, upgrade: Optional[int] = 0) -> str:
+        """Gets html of folder"""
+        
+        if self.stock == "res":
+            data_folder = f"resstock_amy2018_release_{self.release}"
+        elif self.stock == "com":
+            data_folder = f"comstock_amy2018_release_{self.release}"
+        
+        return f"{self.root}/{data_folder}/timeseries_aggregates/by_state/upgrade={upgrade}/state={state.upper()}"
+    
+    def _get_htmls(self, state: str, buildings: str | List[str], upgrade: int = 0) -> List[str]:
+        
+        folder = self._get_html_folder(state)
+        
+        if isinstance(buildings, str):
+            buildings = [buildings]
+        
+        upgrade_padded = f"{upgrade:02d}"
+        
+        htmls = []
+        for building in buildings:
+            htmls.append(f"{folder}/up{upgrade_padded}-{state.lower()}-{building}.csv")
+        
+        return htmls
+    
+    def _request_data(self, url: str, save: str) -> dict[str, dict | str]:
+
+        response = requests.get(url)
+        if response.status_code == 200:
+            with open(save, "wb") as f:
+                f.write(response.content)
+        else:
+            raise requests.ConnectionError(f"Status code {response.status_code}")
+    
+    def _get_building_from_html(self, html: str, state: int) -> str:
+        return html.split(f"-{state.lower()}-")[-1].split(".csv")[0]
+    
+    def _create_save_dir(self, directory: str) -> None:
+        path = Path(directory)
+        if not path.exists():
+            path.mkdir(parents=True, exist_ok=True)
+                
+    def download_data(self, state: str, buildings: Optional[str | List[str]] = None, upgrade: int = 0, directory: Optional[str] = None) -> None:
+        """Public method to interface with"""
+        
+        if not directory:
+            directory = f"{state}"
+        else:
+            directory = f"{directory}/{state}"
+        
+        self._create_save_dir(directory)
+        
+        if not buildings:
+            if self.stock == "res":
+                buildings = self.res_files
+            elif self.stock == "com":
+                buildings = self.com_files
+        
+        htmls = self._get_htmls(state, buildings)
+        
+        for html in htmls:
+            save_name = self._get_building_from_html(html, state)
+            save_path = f"{directory}/{save_name}.csv"
+            self._request_data(html, save_path)
+            
+        
+
+        
+        


### PR DESCRIPTION
## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->
In this PR I add logic to pull and process the [End-Use Load Profile](https://data.openei.org/submissions/4520) dataset from NREL. The data will come in at a state level, separated by electric, heating, and cooling load, and aggregated to an hourly load profile for 2018. I have not done the dissagregation yet, as we should decided on some common data structures for bringing in data. (ie. PR #202)

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
