### PR TITLE
Fix Docs Build Warnings

### DIFF
--- a/workflow/scripts/build_hydro_profile.py
+++ b/workflow/scripts/build_hydro_profile.py
@@ -5,8 +5,7 @@
 """
 Build hydroelectric inflow time-series for each country.
 
-Relevant Settings
------------------
+**Relevant Settings**
 
 .. code:: yaml
 
@@ -21,8 +20,7 @@ Relevant Settings
     Documentation of the configuration file ``config/config.yaml`` at
     :ref:`toplevel_cf`, :ref:`renewable_cf`
 
-Inputs
-------
+**Inputs**
 
 - ``data/bundle/EIA_hydro_generation_2000_2014.csv``: Hydroelectricity net generation per country and year (`EIA <https://www.eia.gov/beta/international/data/browser/#/?pa=000000000000000000000000000000g&c=1028i008006gg6168g80a4k000e0ag00gg0004g800ho00g8&ct=0&ug=8&tl_id=2-A&vs=INTL.33-12-ALB-BKWH.A&cy=2014&vo=0&v=H&start=2000&end=2016>`_)
 
@@ -32,8 +30,7 @@ Inputs
 - ``resources/country_shapes.geojson``: confer :ref:`shapes`
 - ``"cutouts/" + config["renewable"]['hydro']['cutout']``: confer :ref:`cutout`
 
-Outputs
--------
+**Outputs**
 
 - ``resources/profile_hydro.nc``:
 
@@ -50,8 +47,7 @@ Outputs
     .. image:: img/inflow-box.png
         :scale: 33 %
 
-Description
------------
+**Description**
 
 .. seealso::
     :mod:`build_renewable_profiles`

--- a/workflow/scripts/build_renewable_profiles.py
+++ b/workflow/scripts/build_renewable_profiles.py
@@ -9,8 +9,7 @@ under water.
 
 .. note:: Hydroelectric profiles are built in script :mod:`build_hydro_profiles`.
 
-Relevant settings
------------------
+**Relevant settings**
 
 .. code:: yaml
 
@@ -41,8 +40,7 @@ Relevant settings
     Documentation of the configuration file ``config/config.yaml`` at
     :ref:`snapshots_cf`, :ref:`atlite_cf`, :ref:`renewable_cf`
 
-Inputs
-------
+**Inputs**
 
 - ``data/bundle/corine/g250_clc06_V18_5.tif``: `CORINE Land Cover (CLC) <https://land.copernicus.eu/pan-european/corine-land-cover>`_ inventory on `44 classes <https://wiki.openstreetmap.org/wiki/Corine_Land_Cover#Tagging>`_ of land use (e.g. forests, arable land, industrial, urban areas).
 
@@ -63,8 +61,7 @@ Inputs
 - ``"cutouts/" + params["renewable"][{technology}]['cutout']``: :ref:`cutout`
 - ``networks/base.nc``: :ref:`base`
 
-Outputs
--------
+**Outputs**
 
 - `resources/profile_{technology}.nc` with the following structure
 

--- a/workflow/scripts/cluster_network.py
+++ b/workflow/scripts/cluster_network.py
@@ -2,8 +2,7 @@
 Creates networks clustered to ``{cluster}`` number of zones with aggregated
 buses, generators and transmission corridors.
 
-Relevant Settings
------------------
+**Relevant Settings**
 
 .. code:: yaml
 
@@ -24,8 +23,7 @@ Relevant Settings
     Documentation of the configuration file ``config/config.yaml`` at
     :ref:`renewable_cf`, :ref:`solving_cf`, :ref:`lines_cf`
 
-Inputs
-------
+**Inputs**
 
 - ``resources/regions_onshore_elec_s{simpl}.geojson``: confer :ref:`simplify`
 - ``resources/regions_offshore_elec_s{simpl}.geojson``: confer :ref:`simplify`
@@ -33,8 +31,7 @@ Inputs
 - ``networks/elec_s{simpl}.nc``: confer :ref:`simplify`
 - ``data/custom_busmap_elec_s{simpl}_{clusters}.csv``: optional input
 
-Outputs
--------
+**Outputs**
 
 - ``resources/regions_onshore_elec_s{simpl}_{clusters}.geojson``:
 - ``resources/regions_offshore_elec_s{simpl}_{clusters}.geojson``:
@@ -42,8 +39,7 @@ Outputs
 - ``resources/linemap_elec_s{simpl}_{clusters}.csv``: Mapping of lines from ``networks/elec_s{simpl}.nc`` to ``networks/elec_s{simpl}_{clusters}.nc``;
 - ``networks/elec_s{simpl}_{clusters}.nc``:
 
-Description
------------
+**Description**
 
 .. note::
 


### PR DESCRIPTION
Closes #263 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->
Fixes build warnings on duplicate label reference names. Module doc strings should now be displayed on the documentation site. 


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
