### PR TITLE
Fixes Docs Dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![DOI](https://zenodo.org/badge/500892486.svg)](https://zenodo.org/doi/10.5281/zenodo.10815964)
+[![Documentation Status](https://readthedocs.org/projects/pypsa-usa/badge/?version=latest)](https://pypsa-usa.readthedocs.io/en/latest/?badge=latest)
 
 # PyPSA-USA: An Open-Source Energy System Optimization Model for the United States
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,6 +10,9 @@ matplotlib
 scikit-learn
 pyyaml
 seaborn
+snakemake
+cartopy
+plotly
 
 # docs
 myst-parser


### PR DESCRIPTION
Closes #263

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->
Add the following packages to the docs requirements file: 
- snakemake 
- cartopy 
- plotly

This should address the following warnings from readthedocs 
```bash 
WARNING: autodoc: failed to import module ...
```

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
