### PR TITLE
Adds county column to base network 

### DIFF
--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -19,7 +19,7 @@ rule build_shapes:
         offshore_shapes=RESOURCES + "{interconnect}/offshore_shapes.geojson",
         state_shapes=RESOURCES + "{interconnect}/state_boundaries.geojson",
         reeds_shapes=RESOURCES + "{interconnect}/reeds_shapes.geojson",
-        county_shapes=RESOURCES + "{interconnect}/county_shapes.geojson"
+        county_shapes=RESOURCES + "{interconnect}/county_shapes.geojson",
     log:
         "logs/build_shapes/{interconnect}.log",
     threads: 1

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -300,7 +300,7 @@ def dynamic_fuel_price_files(wildcards):
 rule add_electricity:
     params:
         length_factor=config["lines"]["length_factor"],
-        # scaling_factor=config["load"]["scaling_factor"],
+        scaling_factor=config["load"]["scaling_factor"],
         countries=config["countries"],
         renewable=config["renewable"],
         electricity=config["electricity"],

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -12,12 +12,14 @@ rule build_shapes:
         onshore_shapes="repo_data/BA_shapes_new/Modified_BE_BA_Shapes.shp",
         offshore_shapes_ca_osw="repo_data/BOEM_CA_OSW_GIS/CA_OSW_BOEM_CallAreas.shp",
         offshore_shapes_eez=DATA + "eez/conus_eez.shp",
+        county_shapes=DATA + "counties/cb_2020_us_county_500k.shp",
     output:
         country_shapes=RESOURCES + "{interconnect}/country_shapes.geojson",
         onshore_shapes=RESOURCES + "{interconnect}/onshore_shapes.geojson",
         offshore_shapes=RESOURCES + "{interconnect}/offshore_shapes.geojson",
         state_shapes=RESOURCES + "{interconnect}/state_boundaries.geojson",
         reeds_shapes=RESOURCES + "{interconnect}/reeds_shapes.geojson",
+        county_shapes=RESOURCES + "{interconnect}/county_shapes.geojson"
     log:
         "logs/build_shapes/{interconnect}.log",
     threads: 1
@@ -40,6 +42,7 @@ rule build_base_network:
         offshore_shapes=RESOURCES + "{interconnect}/offshore_shapes.geojson",
         state_shapes=RESOURCES + "{interconnect}/state_boundaries.geojson",
         reeds_shapes=RESOURCES + "{interconnect}/reeds_shapes.geojson",
+        county_shapes=RESOURCES + "{interconnect}/county_shapes.geojson",
     output:
         bus2sub=DATA + "breakthrough_network/base_grid/{interconnect}/bus2sub.csv",
         sub=DATA + "breakthrough_network/base_grid/{interconnect}/sub.csv",
@@ -297,7 +300,7 @@ def dynamic_fuel_price_files(wildcards):
 rule add_electricity:
     params:
         length_factor=config["lines"]["length_factor"],
-        scaling_factor=config["load"]["scaling_factor"],
+        # scaling_factor=config["load"]["scaling_factor"],
         countries=config["countries"],
         renewable=config["renewable"],
         electricity=config["electricity"],

--- a/workflow/rules/retrieve.smk
+++ b/workflow/rules/retrieve.smk
@@ -26,7 +26,7 @@ pypsa_usa_datafiles = [
 def define_zenodo_databundles():
     return {
         "USATestSystem": "https://zenodo.org/record/4538590/files/USATestSystem.zip",
-        "pypsa_usa_data": "https://zenodo.org/records/10480944/files/pypsa_usa_data.zip",
+        "pypsa_usa_data": "https://zenodo.org/records/10995249/files/pypsa_usa_data.zip",
     }
 
 

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -1251,7 +1251,16 @@ def clean_bus_data(n: pypsa.Network):
     """
     Drops data from the network that are no longer needed in workflow.
     """
-    col_list = ["poi_bus", "poi_sub", "poi", "Pd", "load_dissag", "LAF", "LAF_states", "county"]
+    col_list = [
+        "poi_bus",
+        "poi_sub",
+        "poi",
+        "Pd",
+        "load_dissag",
+        "LAF",
+        "LAF_states",
+        "county",
+    ]
     n.buses.drop(columns=[col for col in col_list if col in n.buses], inplace=True)
 
 

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -1251,7 +1251,7 @@ def clean_bus_data(n: pypsa.Network):
     """
     Drops data from the network that are no longer needed in workflow.
     """
-    col_list = ["poi_bus", "poi_sub", "poi", "Pd", "load_dissag", "LAF", "LAF_states"]
+    col_list = ["poi_bus", "poi_sub", "poi", "Pd", "load_dissag", "LAF", "LAF_states", "county"]
     n.buses.drop(columns=[col for col in col_list if col in n.buses], inplace=True)
 
 

--- a/workflow/scripts/build_base_network.py
+++ b/workflow/scripts/build_base_network.py
@@ -671,7 +671,7 @@ def main(snakemake):
         columns={"name": "reeds_zone"},
     )
     county_shape = gpd.read_file(snakemake.input["county_shapes"]).rename(
-        columns={"NAME": "county"}
+        columns={"GEOID": "county"}
     )
 
     # assign ba, state, and country to each bus

--- a/workflow/scripts/build_base_network.py
+++ b/workflow/scripts/build_base_network.py
@@ -671,7 +671,7 @@ def main(snakemake):
         columns={"name": "reeds_zone"},
     )
     county_shape = gpd.read_file(snakemake.input["county_shapes"]).rename(
-        columns={"GEOID": "county"}
+        columns={"GEOID": "county"},
     )
 
     # assign ba, state, and country to each bus

--- a/workflow/scripts/build_shapes.py
+++ b/workflow/scripts/build_shapes.py
@@ -361,7 +361,7 @@ def main(snakemake):
     gdf_reeds.to_file(snakemake.output.reeds_shapes)
 
     # read county shapes
-    # takes ~10min to trim shap to interconnect, so skipping 
+    # takes ~10min to trim shap to interconnect, so skipping
     gdf_counties = load_counties_shape(snakemake.input.county_shapes)
     gdf_counties.to_file(snakemake.output.county_shapes)
 

--- a/workflow/scripts/build_shapes.py
+++ b/workflow/scripts/build_shapes.py
@@ -159,6 +159,12 @@ def load_reeds_shape(reeds_shapes: str) -> gpd.GeoDataFrame:
     return gdf.to_crs(4326)
 
 
+def load_counties_shape(shp_file: str) -> gpd.GeoDataFrame:
+    gdf = gpd.read_file(shp_file)
+    gdf = gdf.rename(columns={"rb": "name", "BA_Code": "reeds_ba"})
+    return gdf.to_crs(4326)
+
+
 def combine_offshore_shapes(
     source: str,
     shape: gpd.GeoDataFrame,
@@ -282,21 +288,12 @@ def main(snakemake):
     gdf_na = load_na_shapes()
     gdf_na = gdf_na.query("name not in ['Alaska', 'Hawaii']")
 
-    # Load NERC Shapes
-    gdf_nerc = gpd.read_file(snakemake.input.nerc_shapes)
-
     # Build State Shapes filtered by interconnect
     if interconnect == "western":  # filter states that have any portion in interconnect
         gdf_states = filter_shapes(
             data=gdf_na,
             zones=breakthrough_zones,
             interconnect=interconnect,
-            # add_regions=
-            # [
-            #     "Baja California",
-            #     "British Columbia",
-            #     "Alberta"
-            # ],
         )
     elif interconnect == "texas":
         gdf_states = filter_shapes(
@@ -309,34 +306,12 @@ def main(snakemake):
             data=gdf_na,
             zones=breakthrough_zones,
             interconnect=interconnect,
-            # add_regions=[
-            #     "Saskatchewan",
-            #     "Manitoba",
-            #     "Ontario",
-            #     "Quebec",
-            #     "New Brunswick",
-            #     "Nova Scotia",
-            # ],
         )
-    else:  # Entire US + MX + CA
-        gdf_states = filter_shapes(
-            data=gdf_na,
-            zones=breakthrough_zones,
-            interconnect=interconnect,
-            # add_regions=[
-            #     "Baja California",
-            #     "British Columbia",
-            #     "Alberta",
-            #     "Saskatchewan",
-            #     "Manitoba",
-            #     "Ontario",
-            #     "Quebec",
-            #     "New Brunswick",
-            #     "Nova Scotia",
-            # ],
-        )
+    else:
+        raise NotImplementedError
 
     # Trim gdf_states to only include portions of texas in NERC Interconnect
+    gdf_nerc = gpd.read_file(snakemake.input.nerc_shapes)
     gdf_states = trim_states_to_interconnect(gdf_states, gdf_nerc, interconnect)
 
     # Save NERC Interconnection shapes
@@ -385,6 +360,11 @@ def main(snakemake):
         reeds_exclusion,
     )
     gdf_reeds.to_file(snakemake.output.reeds_shapes)
+
+    # read county shapes
+    # takes ~10min to trim shap to interconnect, so skipping 
+    gdf_counties = load_counties_shape(snakemake.input.county_shapes)
+    gdf_counties.to_file(snakemake.output.county_shapes)
 
     # Load and build offshore shapes
     offshore_config = snakemake.params.source_offshore_shapes["use"]

--- a/workflow/scripts/build_shapes.py
+++ b/workflow/scripts/build_shapes.py
@@ -161,7 +161,6 @@ def load_reeds_shape(reeds_shapes: str) -> gpd.GeoDataFrame:
 
 def load_counties_shape(shp_file: str) -> gpd.GeoDataFrame:
     gdf = gpd.read_file(shp_file)
-    gdf = gdf.rename(columns={"rb": "name", "BA_Code": "reeds_ba"})
     return gdf.to_crs(4326)
 
 


### PR DESCRIPTION
Closes #275 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->
In this PR I assign buses to counties in the base network. County level shapes have been added to the pypsa-usa databundle to zenodo. The county data is dropped at the end of add_electricity due to clustering issues if the shapes are retained. Counties are assigned their numerical value (geoid), rather than their human readable name. Note, counties are based on 2020 data, as this needs to be synced with population 2020 data. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
