### PR TITLE
Index snapshots by planning horizon 

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -10,6 +10,7 @@ HTTP = HTTPRemoteProvider()
 from os.path import normpath
 from itertools import chain
 from pathlib import Path
+import pandas as pd
 
 FIGURES_MAPS = [
     "capacity_map_base.pdf",

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -33,6 +33,7 @@ rule build_base_network:
     params:
         build_offshore_network=config["offshore_network"],
         snapshots=config["snapshots"],
+        planning_horizons=config["scenario"]["planning_horizons"],
         links=config["links"],
     input:
         buses=DATA + "breakthrough_network/base_grid/bus.csv",

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -268,9 +268,9 @@ rule build_electrical_demand:
     wildcard_constraints:
         end_use="power",  # added for consistency in build_demand.py
     params:
-        planning_horizons=config["scenario"]["planning_horizons"],
         demand_params=config["electricity"]["demand"],
         eia_api=config["api"]["eia"],
+        profile_year=pd.to_datetime(config["snapshots"]["start"]).year,
     input:
         network=RESOURCES + "{interconnect}/elec_base_network.nc",
         demand_files=electricty_study_demand,

--- a/workflow/scripts/add_demand.py
+++ b/workflow/scripts/add_demand.py
@@ -43,7 +43,6 @@ if __name__ == "__main__":
 
     demand_files = snakemake.input.demand
     n = pypsa.Network(snakemake.input.network)
-    n.set_investment_periods(periods=snakemake.params.planning_horizons)
 
     sectors = snakemake.params.sectors
 

--- a/workflow/scripts/add_demand.py
+++ b/workflow/scripts/add_demand.py
@@ -38,7 +38,7 @@ def attach_demand(n: pypsa.Network, df: pd.DataFrame, carrier: str, suffix: str)
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
-        snakemake = mock_snakemake("add_demand", interconnect="texas")
+        snakemake = mock_snakemake("add_demand", interconnect="western")
     configure_logging(snakemake)
 
     demand_files = snakemake.input.demand

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -1074,6 +1074,9 @@ def main(snakemake):
                 # if data should exist, try to read it in
                 try:
                     df = pd.read_csv(snakemake.input[datafile], index_col="snapshot")
+                    if df.empty:
+                        logger.warning(f"No data provided for {datafile}")
+                        continue
                 except KeyError:
                     logger.warning(f"Can not find dynamic price file {datafile}")
                     continue

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -413,13 +413,12 @@ def attach_breakthrough_renewable_plants(
         )  # filters by plants ID for the plants of type tech
         p_nom_be = p_nom_be[list(intersection)]
 
-        Nhours = len(n.snapshots.get_level_values(1).unique())
-        p_nom_be = p_nom_be.iloc[
-            :Nhours,
-            :,
-        ]  # hotfix to fit 2016 renewable data to load data
-        p_nom_be.index = n.snapshots.get_level_values(1).unique()
+        # hotfix to fit 2016 renewable data to load data
         p_nom_be.columns = p_nom_be.columns.astype(str)
+        p_nom_be.index = pd.to_datetime(p_nom_be.index, format="%Y-%m-%d %H:%M:%S")
+        # convert to 2016 first to account for leap year
+        sns_2016 = n.snapshots.get_level_values(1).map(lambda x: x.replace(year=2016))
+        p_nom_be = p_nom_be[p_nom_be.index.isin(sns_2016)]
 
         if (tech_plants.Pmax == 0).any():
             # p_nom is the maximum of {Pmax, dispatch}
@@ -1116,6 +1115,6 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("add_electricity", interconnect="western")
+        snakemake = mock_snakemake("add_electricity", interconnect="texas")
     configure_logging(snakemake)
     main(snakemake)

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -246,7 +246,7 @@ def add_missing_heat_rates(plants, heat_rates_fn):
     hr_mapped = (
         plants.fuel_type.map(heat_rates.heat_rate_btu_per_kwh) / 1000
     )  # convert to mmbtu/mwh
-    plants["heat_rate"].fillna(hr_mapped, inplace=True)
+    plants["heat_rate"] = plants["heat_rate"].fillna(hr_mapped)
     return plants
 
 
@@ -272,7 +272,7 @@ def update_capital_costs(
 
     # map generators to states
     bus_state_mapper = n.buses.to_dict()["state"]
-    gen = n.generators[n.generators.carrier == carrier].copy()  # copy with warning
+    gen = n.generators[n.generators.carrier == carrier].copy()
     gen["state"] = gen.bus.map(bus_state_mapper)
     gen = gen[
         gen["state"].isin(multiplier.index)
@@ -282,12 +282,6 @@ def update_capital_costs(
     missed = gen[~gen["state"].isin(multiplier.index)]
     if not missed.empty:
         logger.warning(f"CAPEX cost multiplier not applied to {missed.state.unique()}")
-
-    # apply multiplier
-
-    # commented code is if applying multiplier to (capex + fom)
-    # gen["capital_cost"] = gen.apply(
-    #     lambda x: x["capital_cost"] * multiplier.at[x["state"], "Location Variation"], axis=1)
 
     # apply multiplier to annualized capital investment cost
     gen["investment"] = gen.apply(
@@ -342,7 +336,7 @@ def apply_dynamic_pricing(
     fuel_cost_per_gen = {gen: df[gens.at[gen, geography]] for gen in gens.index}
     fuel_costs = pd.DataFrame.from_dict(fuel_cost_per_gen)
     fuel_costs.index = pd.to_datetime(fuel_costs.index)
-    fuel_costs = broadcast_investment_horizons_index(n.snapshots, fuel_costs)
+    fuel_costs = broadcast_investment_horizons_index(n, fuel_costs)
 
     marginal_costs = fuel_costs.div(eff, axis=1)
     marginal_costs = marginal_costs + vom
@@ -437,7 +431,7 @@ def attach_breakthrough_renewable_plants(
             p_nom = tech_plants.Pmax
             p_max_pu = p_nom_be[tech_plants.index] / p_nom
 
-        p_max_pu = broadcast_investment_horizons_index(n.snapshots, p_max_pu)
+        p_max_pu = broadcast_investment_horizons_index(n, p_max_pu)
 
         n.madd(
             "Generator",
@@ -687,10 +681,7 @@ def attach_wind_and_solar(
                 .drop(columns="sub_id")
                 .T
             )
-            bus_profiles = broadcast_investment_horizons_index(
-                n.snapshots,
-                bus_profiles,
-            )
+            bus_profiles = broadcast_investment_horizons_index(n, bus_profiles)
 
             if supcar == "offwind":
                 capital_cost = capital_cost.to_frame().reset_index()
@@ -847,15 +838,22 @@ def load_powerplants_eia(
     return plants
 
 
-def broadcast_investment_horizons_index(sns, df):
+def broadcast_investment_horizons_index(n: pypsa.Network, df: pd.DataFrame):
     """
     Broadcast the index of a dataframe to match the potentially multi-indexed
     investment periods of a PyPSA network.
     """
-    if len(df.index) == len(sns):
-        df.index = sns
-    else:  # if broadcasting is necessary
-        df = df.reindex(sns, level=1)
+    sns = n.snapshots
+    if not len(df.index) == len(sns):  # if broadcasting is necessary
+        df.index = pd.to_datetime(df.index)
+        dfs = []
+        for planning_horizon in n.investment_periods.to_list():
+            period_data = df.copy()
+            period_data.index = df.index.map(lambda x: x.replace(year=planning_horizon))
+            dfs.append(period_data)
+        df = pd.concat(dfs)
+        assert len(df.index) == len(sns)
+    df.index = sns
     return df
 
 
@@ -884,7 +882,7 @@ def apply_seasonal_capacity_derates(
         "winter_derate",
     ].astype(float)
 
-    p_max_pu = broadcast_investment_horizons_index(sns, p_max_pu)
+    p_max_pu = broadcast_investment_horizons_index(n, p_max_pu)
     n.generators_t.p_max_pu = pd.concat([n.generators_t.p_max_pu, p_max_pu], axis=1)
 
 
@@ -913,7 +911,7 @@ def apply_must_run_capacity_ratings(
     p_min_pu = pd.DataFrame(1.0, index=sns_dt, columns=must_run.index)
     p_min_pu.loc[:, must_run.index] *= must_run.loc[:, "minimum_cf"].astype(float)
 
-    p_min_pu = broadcast_investment_horizons_index(sns, p_min_pu)
+    p_min_pu = broadcast_investment_horizons_index(n, p_min_pu)
     n.generators_t.p_min_pu = pd.concat([n.generators_t.p_min_pu, p_min_pu], axis=1)
 
 
@@ -1118,6 +1116,6 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("add_electricity", interconnect="texas")
+        snakemake = mock_snakemake("add_electricity", interconnect="western")
     configure_logging(snakemake)
     main(snakemake)

--- a/workflow/scripts/build_base_network.py
+++ b/workflow/scripts/build_base_network.py
@@ -823,10 +823,7 @@ def main(snakemake):
     planning_horizons = snakemake.params.planning_horizons
     sns = make_snapshots(sns_config, planning_horizons)
     n.snapshots = sns
-    if planning_horizons:
-        n.set_investment_periods(periods=planning_horizons)
-    else:
-        n.set_investment_periods(periods=n.snapshots[0].year)
+    n.set_investment_periods(periods=planning_horizons)
 
     # export network
     n.export_to_netcdf(snakemake.output.network)

--- a/workflow/scripts/build_base_network.py
+++ b/workflow/scripts/build_base_network.py
@@ -644,10 +644,14 @@ def make_snapshots(
         invest_periods = [pd.to_datetime(sns_config["start"]).year]
     sns = pd.DatetimeIndex([])
     for year in invest_periods:
+        start = pd.to_datetime(sns_config["start"])
+        end = pd.to_datetime(sns_config["end"])
+        year_diff = end.year - start.year
+        assert year_diff in (0, 1)
         period = pd.date_range(
             freq="h",
-            start=pd.to_datetime(sns_config["start"]).replace(year=year),
-            end=pd.to_datetime(sns_config["end"]).replace(year=year),
+            start=start.replace(year=year),
+            end=end.replace(year=(year + year_diff)),
             inclusive=sns_config["inclusive"],
         )
         sns = sns.append(period)
@@ -833,6 +837,6 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("build_base_network", interconnect="western")
+        snakemake = mock_snakemake("build_base_network", interconnect="texas")
     configure_logging(snakemake)
     main(snakemake)

--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -1178,7 +1178,7 @@ if __name__ == "__main__":
         )  # dict[str, dict[str, pd.DataFrame]]
 
     # assign demand to planning years and scale
-    demand = expand_demand(
+    demands = expand_demand(
         demands,
         planning_horizons,
         scale_method,

--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -619,9 +619,6 @@ class WriteStrategy(ABC):
         # get implementation specific dissgregation factors
         laf = self._get_load_allocation_factor(df=dissagregation_zones, zone=zone)
 
-        # checks that sum of all LAFs is equal to the number of zones.
-        # assert abs(laf.sum() - len(dissagregation_zones.unique())) <= 0.0001
-
         # disaggregate load to buses
         zone_data = dissagregation_zones.to_frame(name="zone").join(
             laf.to_frame(name="laf"),
@@ -661,7 +658,9 @@ class WriteStrategy(ABC):
         """
         filtered = df[df.index.get_level_values("snapshot").isin(sns)].copy()
         filtered = filtered[~filtered.index.duplicated(keep="last")]  # issue-272
-        assert len(filtered.index.get_level_values("snapshot").unique()) == len(sns)
+        assert len(filtered.index.get_level_values("snapshot").unique()) == len(
+            sns.unique(),
+        )
         return filtered
 
     @staticmethod
@@ -693,15 +692,11 @@ class WriteStrategy(ABC):
 
         n = self.n
 
-        if isinstance(sns, pd.DatetimeIndex):  # not sure if leap years will break this
-            snapshots = sns
-            assert len(snapshots) == len(n.snapshots)
-            filtered = self._filter_on_snapshots(df, snapshots)
+        if isinstance(sns, pd.DatetimeIndex):
+            assert len(sns) == len(n.snapshots)
+            filtered = self._filter_on_snapshots(df, sns)
             df = filtered.reset_index()
             df = df.groupby(["snapshot", "sector", "subsector", "fuel"]).sum()
-            # df["snapshot"] = df.snapshot.map(
-            #     lambda x: x.replace(year=n.snapshots.get_level_values(1)[0].year),
-            # ) # remove this so we retain true snapshot dates
             assert filtered.shape == df.shape  # no data should have changed
         else:  # profile and planning year are the same
             snapshots = n.snapshots
@@ -949,6 +944,77 @@ class WriteIndustrial(WriteStrategy):
 ###
 
 
+def reindex_demand(df: pd.DataFrame, year: int) -> pd.DataFrame:
+    """
+    Reindex a dataframe for a different planning horizon.
+
+    Input dataframe will be...
+
+    |                     | BusName_1 | BusName_2 | ... | BusName_n |
+    |---------------------|-----------|-----------|-----|-----------|
+    | 2019-01-01 00:00:00 |    aaa    |    ddd    |     |    ggg    |
+    | 2019-01-01 01:00:00 |    bbb    |    eee    |     |    hhh    |
+    | ...                 |    ...    |    ...    |     |    ...    |
+    | 2019-02-28 23:00:00 |    ccc    |    fff    |     |    iii    |
+
+    Output dataframe will be...
+
+    |                     | BusName_1 | BusName_2 | ... | BusName_n |
+    |---------------------|-----------|-----------|-----|-----------|
+    | 2030-01-01 00:00:00 |    aaa    |    ddd    |     |    ggg    |
+    | 2030-01-01 01:00:00 |    bbb    |    eee    |     |    hhh    |
+    | ...                 |    ...    |    ...    |     |    ...    |
+    | 2030-02-28 23:00:00 |    ccc    |    fff    |     |    iii    |
+    """
+
+    new = df.copy()
+    new.index = new.index.map(lambda x: x.replace(year=year))
+    return new
+
+
+def expand_demand(
+    demands: dict[str, dict[str : pd.DataFrame]],
+    planning_horizons: list[int],
+    scale_method: str,
+) -> dict[str, dict[str : pd.DataFrame]]:
+    """
+    Expands demand to match planning horizons.
+    """
+
+    expanded = {}
+
+    for sector, fuels in demands.items():
+        expanded[sector] = {}
+        for fuel, demand in fuels.items():
+            dfs = []
+            for planning_horizon in planning_horizons:
+                df = demand[demand.index.year == planning_horizon]
+                if not df.empty:
+                    dfs.append(df)
+                else:
+                    profile_year = demand.index[0].year
+                    df = demand[demand.index.year == profile_year]
+                    df = reindex_demand(df, planning_horizon)
+                    # scale demand here
+                    dfs.append(df)
+            expanded[sector][fuel] = pd.concat(dfs)
+    return expanded
+
+
+def scale_demand(method: str):
+    """
+    Scales demand.
+    """
+    if method == "efs":
+        growth_rate = ReadEfs(snakemake.input.efs).get_growth_rate()
+        logger.warning("No scale appied for efs data")
+    elif method == "aeo":
+        growth_rate = get_aeo_growth_rate(eia_api, [profile_year, planning_horizons])
+        logger.warning("No scale appied for aeo data")
+    else:
+        raise NotImplementedError
+
+
 def get_aeo_growth_rate(
     api: str,
     years: list[str],
@@ -1029,13 +1095,12 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "build_electrical_demand",
-            interconnect="texas",
+            interconnect="western",
             end_use="power",
         )
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)
-    n.set_investment_periods(periods=snakemake.params.planning_horizons)
 
     # extract user demand configuration parameters
 
@@ -1045,18 +1110,18 @@ if __name__ == "__main__":
 
     if end_use == "power":  # electricity only study
         demand_profile = demand_params["profile"]
-        demand_scale = demand_params["scale"]
+        scale_method = demand_params["scale"]
         demand_disaggregation = demand_params["disaggregation"]
     else:
         demand_profile = demand_params["profile"][end_use]
-        demand_scale = demand_params["scale"][end_use]
+        scale_method = demand_params["scale"][end_use]
         demand_disaggregation = demand_params["disaggregation"][end_use]
 
-    if demand_scale == "aeo":
+    if scale_method == "aeo":
         assert eia_api, "Must provide EIA API key to scale demand by AEO"
 
-    profile_year = int(n.snapshots.get_level_values(1)[0].year)
-    planning_horizons = snakemake.params.planning_horizons
+    planning_horizons = n.investment_periods.to_list()
+    profile_year = snakemake.params.profile_year
 
     # set reading and writitng strategies
 
@@ -1067,27 +1132,23 @@ if __name__ == "__main__":
             year in (2018, 2020, 2024, 2030, 2040, 2050) for year in planning_horizons
         )
         reader = ReadEfs(demand_files)
-        sns_year = n.snapshots.get_level_values(0)
-        sns_dt = n.snapshots.get_level_values(1)
-        sns = pd.DatetimeIndex(
-            [x.replace(year=sns_year[i]) for i, x in enumerate(sns_dt)],
-        )
-        profile_year = planning_horizons[
-            0
-        ]  # do not scale EFS data #revisit this if we want to scale
+        sns = n.snapshots.get_level_values(1)
+
     elif demand_profile == "eia":
         assert profile_year in range(2018, 2023, 1)
         reader = ReadEia(demand_files)
-        sns_year = n.snapshots.get_level_values(0)
-        sns_dt = n.snapshots.get_level_values(1)
-        sns = pd.DatetimeIndex(
-            [x.replace(year=sns_year[i]) for i, x in enumerate(sns_dt)],
+        sns = n.snapshots.get_level_values(1).map(
+            lambda x: x.replace(year=profile_year),
         )
+
     elif demand_profile == "eulp":
-        # assert profile_year == 2018
         stock = {"residential": "res", "commercial": "com"}
         reader = ReadEulp(demand_files, stock[end_use])  # 'res' or 'com'
-        sns = n.snapshots
+        # assert profile_year == 2018,
+        sns = n.snapshots.get_level_values(1).map(
+            lambda x: x.replace(year=profile_year),
+        )
+
     else:
         raise NotImplementedError
 
@@ -1102,6 +1163,7 @@ if __name__ == "__main__":
     demand_converter = Context(reader, writer)
 
     # extract demand based on strategies
+    # this is raw demand, not scaled or garunteed to align to snapshots
 
     if end_use == "power":  # only one demand for electricity only studies
         demand = demand_converter.prepare_demand(sns=sns)  # pd.DataFrame
@@ -1115,17 +1177,12 @@ if __name__ == "__main__":
             sns=sns,
         )  # dict[str, dict[str, pd.DataFrame]]
 
-    # scale demand based on planning year and user input
-    if profile_year == planning_horizons[0]:
-        pass
-    elif isinstance(demand_scale, (int, float)):
-        demand *= demand_scale
-    elif demand_scale == "efs":
-        growth_rate = ReadEfs(snakemake.input.efs).get_growth_rate()
-        logger.warning("No scale appied for efs data")
-    elif demand_scale == "aeo":
-        growth_rate = get_aeo_growth_rate(eia_api, [profile_year, planning_horizons])
-        logger.warning("No scale appied for aeo data")
+    # assign demand to planning years and scale
+    demand = expand_demand(
+        demands,
+        planning_horizons,
+        scale_method,
+    )  # dict[str, dict[str, pd.DataFrame]]
 
     # electricity sector study
     if end_use == "power":

--- a/workflow/scripts/cluster_network.py
+++ b/workflow/scripts/cluster_network.py
@@ -456,6 +456,9 @@ if __name__ == "__main__":
     solver_name = snakemake.config["solving"]["solver"]["name"]
 
     n = pypsa.Network(snakemake.input.network)
+    n.set_investment_periods(
+        periods=snakemake.params.planning_horizons,
+    )
 
     exclude_carriers = params.cluster_network["exclude_carriers"]
     aggregate_carriers = set(n.generators.carrier) - set(exclude_carriers)

--- a/workflow/scripts/prepare_network.py
+++ b/workflow/scripts/prepare_network.py
@@ -297,10 +297,10 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "prepare_network",
             simpl="",
-            clusters="10",
-            interconnect="texas",
+            clusters="80",
+            interconnect="western",
             ll="v1.0",
-            opts="RCo2L-1000SEG",
+            opts="Ep-Co2L0.2.nc",
         )
     configure_logging(snakemake)
     set_scenario_config(snakemake)
@@ -316,7 +316,10 @@ if __name__ == "__main__":
     )
 
     # Set Investment Period Year Weightings
-    inv_per_time_weight = n.investment_periods.to_series().diff().shift(-1).ffill()
+    # 'fillna(1)' needed if only one period
+    inv_per_time_weight = (
+        n.investment_periods.to_series().diff().shift(-1).ffill().fillna(1)
+    )
     n.investment_period_weightings["years"] = inv_per_time_weight
     # set Investment Period Objective weightings
     social_discountrate = snakemake.params.costs["social_discount_rate"]


### PR DESCRIPTION
Closes #335 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->
In this PR I have changed the indexing logic to be the planning horizon instead of the profile year. This includes: 
- Adding multi-index to all snapshot data (regardless if it is single horizon or not) in `build_base_network`
- Updating demand to export planning horizon data (note, not scaled data yet) - the `expand_demand` function is a little awkward, but it will allow for addition of scaling demand relatively easily. 
- Updating data in `add_electricity` to account for planning horizon (ie. renewables, fuel prices, ect...) through updated `broadcast_investment_horizon_index` function 

I have checked that both single horizon and multi-horizon data still works. Todo before merging: 
- [x] Confirm all plots still look correct 
- [x] Compare this PR against current develop branch to check nothing has changed (other than indexing) - but objective cost and other results should still be the same 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
