### PR TITLE
Fixes leap years

### DIFF
--- a/workflow/scripts/_helpers.py
+++ b/workflow/scripts/_helpers.py
@@ -852,3 +852,22 @@ def path_provider(dir, rdir, shared_resources):
         returns the path to the file based on the shared_resources parameter.
     """
     return partial(get_run_path, dir=dir, rdir=rdir, shared_resources=shared_resources)
+
+
+def get_snapshots(
+    snapshots: dict[str, str],
+    drop_leap_day: bool = True,
+    freq: str = "h",
+    **kwargs,
+) -> pd.date_range:
+    """
+    Returns pandas DateTimeIndex potentially without leap days.
+
+    Taken from PyPSA-Eur implementation
+    """
+
+    time = pd.date_range(freq=freq, **snapshots, **kwargs)
+    if drop_leap_day and time.is_leap_year.any():
+        time = time[~((time.month == 2) & (time.day == 29))]
+
+    return time

--- a/workflow/scripts/add_sectors.py
+++ b/workflow/scripts/add_sectors.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 import sys
 
 import constants
-from _helpers import configure_logging
+from _helpers import configure_logging, get_snapshots
 from build_natural_gas import build_natural_gas
 from shapely.geometry import Point
 
@@ -94,10 +94,12 @@ if __name__ == "__main__":
     code_2_state = {v: k for k, v in constants.STATE_2_CODE.items()}
     assign_bus_2_state(n, snakemake.input.county, states_2_map, code_2_state)
 
+    sns = get_snapshots(snakemake.params.snapshots)
+
     if "G" in sectors:
         build_natural_gas(
             n=n,
-            year=pd.to_datetime(snakemake.params.snapshots["start"]).year,
+            year=sns[0].year,
             api=snakemake.params.api["eia"],
             interconnect=snakemake.wildcards.interconnect,
             county_path=snakemake.input.county,

--- a/workflow/scripts/build_cutout.py
+++ b/workflow/scripts/build_cutout.py
@@ -90,7 +90,7 @@ import logging
 import atlite
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging
+from _helpers import configure_logging, get_snapshots
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +107,7 @@ if __name__ == "__main__":
 
     # data set and temporal patameters
     cutout_params = snakemake.params.cutouts[snakemake.wildcards.cutout]
-    snapshots = pd.date_range(freq="h", **snakemake.params.snapshots)
+    snapshots = get_snapshots(snakemake.params.snapshots)
     time = [snapshots[0], snapshots[-1]]
     cutout_params["time"] = slice(*cutout_params.get("time", time))
 

--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -1095,7 +1095,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "build_electrical_demand",
-            interconnect="western",
+            interconnect="texas",
             end_use="power",
         )
     configure_logging(snakemake)

--- a/workflow/scripts/build_fuel_prices.py
+++ b/workflow/scripts/build_fuel_prices.py
@@ -29,7 +29,7 @@ from typing import List
 import constants as const
 import eia
 import pandas as pd
-from _helpers import configure_logging, mock_snakemake
+from _helpers import configure_logging, get_snapshots, mock_snakemake
 
 logger = logging.getLogger(__name__)
 
@@ -152,19 +152,9 @@ if __name__ == "__main__":
         snakemake = mock_snakemake("build_fuel_prices", interconnect="western")
     configure_logging(snakemake)
 
-    snapshot_config = snakemake.config["snapshots"]
-    sns_start = pd.to_datetime(snapshot_config["start"])
-    sns_end = pd.to_datetime(snapshot_config["end"])
-    sns_inclusive = snapshot_config["inclusive"]
-
     eia_api = snakemake.params.api_eia
 
-    snapshots = pd.date_range(
-        freq="h",
-        start=sns_start,
-        end=sns_end,
-        inclusive=sns_inclusive,
-    )
+    snapshots = get_snapshots(snakemake.params.snapshots)
 
     function_mapper = {
         "caiso_ng_power_prices": get_caiso_ng_power_prices,

--- a/workflow/scripts/build_renewable_profiles.py
+++ b/workflow/scripts/build_renewable_profiles.py
@@ -164,7 +164,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import xarray as xr
-from _helpers import configure_logging
+from _helpers import configure_logging, get_snapshots
 from dask.distributed import Client
 from pypsa.geo import haversine
 from shapely.geometry import LineString
@@ -203,7 +203,7 @@ if __name__ == "__main__":
     else:
         client = None
 
-    sns = pd.date_range(freq="h", **snakemake.config["snapshots"])
+    sns = get_snapshots(snakemake.params.snapshots)
     cutout = atlite.Cutout(snakemake.input.cutout).sel(time=sns)
 
     regions = gpd.read_file(snakemake.input.regions)

--- a/workflow/scripts/plot_validation_production.py
+++ b/workflow/scripts/plot_validation_production.py
@@ -10,7 +10,7 @@ import pypsa
 import seaborn as sns
 
 logger = logging.getLogger(__name__)
-from _helpers import configure_logging
+from _helpers import configure_logging, get_snapshots
 from constants import EIA_930_REGION_MAPPER, EIA_BA_2_REGION, STATE_2_CODE
 from eia import Emissions
 from plot_network_maps import (
@@ -738,14 +738,13 @@ def main(snakemake):
     colors["imports"] = "#7d1caf"
     colors["exports"] = "#d624d9"
 
+    snapshots = get_snapshots(snakemake.params.snapshots)
+
     plot_state_emissions_historical_bar(
         n,
         ge_co2,
         snakemake.output["val_bar_state_emissions.pdf"],
-        pd.date_range(
-            start=snakemake.params.snapshots["start"],
-            end=snakemake.params.snapshots["end"],
-        ),
+        snapshots,
         snakemake.params.eia_api,
         **snakemake.wildcards,
     )
@@ -770,10 +769,7 @@ def main(snakemake):
         n,
         ge_co2,
         snakemake.output["val_bar_regional_emissions.pdf"],
-        pd.date_range(
-            start=snakemake.params.snapshots["start"],
-            end=snakemake.params.snapshots["end"],
-        ),
+        snapshots,
         snakemake.params.eia_api,
         **snakemake.wildcards,
     )


### PR DESCRIPTION
Closes #347, Closes #225 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->
Pulls in the PyPSA-Eur function for creating snapshots, which handles leap years (via the new function `get_snapshots(...)`). Current implementation is that leap year day (feb 29) will be dropped. Associated function calls throughout the workflow have been updated to always use this function. Creation of mulit-index snapshots has been updated to use this function and renamed to `get_multiindex_snapshots(...)`

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
