### PR TITLE
Updates Unit Commitment Parameters

### DIFF
--- a/workflow/repo_data/config/config.default.yaml
+++ b/workflow/repo_data/config/config.default.yaml
@@ -181,6 +181,9 @@ clustering:
   aggregation_strategies:
     generators:
       committable: any
+      start_up_cost: 'capacity_weighted_average'
+      min_up_time: 'capacity_weighted_average'
+      min_down_time: 'capacity_weighted_average'
       ramp_limit_up: max
       ramp_limit_down: max
       vom_cost: mean

--- a/workflow/repo_data/config/config.validation.yaml
+++ b/workflow/repo_data/config/config.validation.yaml
@@ -177,6 +177,9 @@ clustering:
   aggregation_strategies:
     generators:
       committable: any
+      start_up_cost: 'capacity_weighted_average'
+      min_up_time: 'capacity_weighted_average'
+      min_down_time: 'capacity_weighted_average'
       ramp_limit_up: max
       ramp_limit_down: max
       vom_cost: mean

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -157,9 +157,9 @@ def interconnect_mem_c(w):
     elif w.interconnect == "eastern":
         return int(mem * 3)
     elif w.interconnect == "western":
-        return int(mem)
+        return int(mem) * 2
     elif w.interconnect == "texas":
-        return int(mem * 0.5)
+        return int(mem * 0.75)
 
 
 def input_custom_extra_functionality(w):

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -439,7 +439,7 @@ def attach_renewable_capacities_to_atlite(
             missing_capacity = caps_per_bus[
                 ~caps_per_bus.index.isin(generators_tech.sub_assignment)
             ].sum()
-            missing_plants.to_csv(f"missing_{tech}_plants.csv",)
+            # missing_plants.to_csv(f"missing_{tech}_plants.csv",)
 
             logger.info(
                 f"There are {np.round(missing_capacity/1000,4)} GW of {tech} plants that are not in the network. See git issue #16.",
@@ -878,6 +878,10 @@ def load_powerplants_eia(
     data_fields = ['start_up_cost', 'min_down_time', 'min_up_time', "ramp_limit_up", "ramp_limit_down"]
     plants = impute_missing_plant_data(plants, aggregation_fields, data_fields)
 
+    aggregation_fields = ["nerc_region", "technology"]
+    data_fields = ['heat_rate']
+    plants = impute_missing_plant_data(plants, aggregation_fields, data_fields)
+
     plants["marginal_cost"] = (
         plants.heat_rate * plants.fuel_cost
     )  # (MMBTu/MW) * (USD/MMBTu) = USD/MW
@@ -1286,6 +1290,6 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("add_electricity", interconnect="texas")
+        snakemake = mock_snakemake("add_electricity", interconnect="western")
     configure_logging(snakemake)
     main(snakemake)

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -1054,12 +1054,6 @@ def attach_breakthrough_renewable_plants(
         )  # filters by plants ID for the plants of type tech
         p_nom_be = p_nom_be[list(intersection)]
 
-        Nhours = len(n.snapshots.get_level_values(1).unique())
-        p_nom_be = p_nom_be.iloc[
-            :Nhours,
-            :,
-        ]  # hotfix to fit 2016 renewable data to load data
-        p_nom_be.index = n.snapshots.get_level_values(1).unique()
         p_nom_be.columns = p_nom_be.columns.astype(str)
 
         if (tech_plants.Pmax == 0).any():
@@ -1072,6 +1066,8 @@ def attach_breakthrough_renewable_plants(
             p_nom = tech_plants.Pmax
             p_max_pu = p_nom_be[tech_plants.index] / p_nom
 
+        leap_day = p_max_pu.loc['2016-02-29 00:00:00':'2016-02-29 23:00:00']
+        p_max_pu = p_max_pu.drop(leap_day.index)
         p_max_pu = broadcast_investment_horizons_index(n, p_max_pu)
 
         n.madd(

--- a/workflow/scripts/build_shapes.py
+++ b/workflow/scripts/build_shapes.py
@@ -366,7 +366,7 @@ def main(snakemake):
             "p19",
         ],
         "eastern": ["p19", "p34", "p32", "p31", "p18"],
-        "texas": ["p31", "p59", "p50", "p85", "p58", "p57", "p66", "p47", "p48"],
+        "texas": ["p31", "p59", "p50", "p85", "p58", "p57", "p66", "p47"],
     }
 
     gdf_reeds = trim_shape_to_interconnect(

--- a/workflow/scripts/plot_statistics.py
+++ b/workflow/scripts/plot_statistics.py
@@ -81,6 +81,8 @@ def get_color_palette(n: pypsa.Network) -> dict[str, str]:
         "battery_charger": n.carriers.loc["battery"].color,
         "4hr_battery_storage_discharger": n.carriers.loc["4hr_battery_storage"].color,
         "4hr_battery_storage_charger": n.carriers.loc["4hr_battery_storage"].color,
+        "8hr_battery_storage_discharger": n.carriers.loc["8hr_battery_storage"].color,
+        "8hr_battery_storage_charger": n.carriers.loc["8hr_battery_storage"].color,
         "co2": "k",
     }
 

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -609,7 +609,7 @@ def add_regional_co2limit(n, sns, config):
             )
 
             logger.info(
-                f"Adding regional Co2 Limit for {emmission_lim.name} in {planning_horizon}"
+                f"Adding regional Co2 Limit for {emmission_lim.name} in {planning_horizon}",
             )
 
 


### PR DESCRIPTION
This change primarily updates unit-commitment parameters, ramping rates, and heat-rates for non-WECC generators.

- Generators with missing Unit-commitment parameters are assigned values from EIA-technology based capacity weighted averages from the ADS
- Likewise for the few plants missing e-grid heat-rates we update based on technology level capacity weighted averages.
- #16 Fix to ensure most of the renewable plants are added to the system. A small residual remains, need to investigate further why these aren't added to the network.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
