### PR TITLE
Scales Demand 

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -88,7 +88,7 @@ wildcard_constraints:
 
 
 # Merge subworkflow configs and main config
-configfile: "config/config.validation.yaml"
+configfile: "config/config.default.yaml"
 configfile: "config/config.cluster.yaml"
 configfile: "config/config.common.yaml"
 configfile: "config/config.plotting.yaml"

--- a/workflow/repo_data/config/config.default.yaml
+++ b/workflow/repo_data/config/config.default.yaml
@@ -67,9 +67,7 @@ electricity:
     Link: [] 
 
   demand: 
-    profile: efs # efs, eia
-    scale: 1 # efs, aeo, or a number 
-    disaggregation: pop # pop
+    profile: eia # efs, eia
     scenario: 
       efs_case: reference # reference, medium, high
       efs_speed: moderate # slow, moderate, rapid

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -215,18 +215,40 @@ INTERCONNECT_2_STATE["eastern"].extend(["RI", "SC", "SD", "TN", "VT", "VA", "WV"
 INTERCONNECT_2_STATE["usa"] = sum(INTERCONNECT_2_STATE.values(), [])
 
 
-def electricty_study_demand(wildcards):
-    profile = config["electricity"]["demand"]["profile"]
+def demand_raw_data(wildcards):
+    end_use = wildcards.end_use
+    if end_use == "power":
+        profile = config["electricity"]["demand"]["profile"]
+    else:
+        profile = config["sector"]["demand"]["profile"][end_use]
+
     if profile == "eia":
         return DATA + "GridEmissions/EIA_DMD_2018_2024.csv"
     elif profile == "efs":
         return DATA + "nrel_efs/EFSLoadProfile_Reference_Moderate.csv"
+    elif profile == "eulp":
+        return [
+            DATA + f"eulp/res/{state}.csv"
+            for state in INTERCONNECT_2_STATE[wildcards.interconnect]
+        ]
+    elif profile == "cliu":
+        return [
+            DATA + "industry_load/2014_update_20170910-0116.csv",  # cliu data
+            DATA + "industry_load/epri_industrial_loads.csv",  # epri data
+            DATA + "industry_load/table3_2.xlsx",  # mecs data
+            DATA + "industry_load/fips_codes.csv",  # fips data
+        ]
     else:
         return ""
 
 
-def electricty_study_dissagregate(wildcards):
-    strategy = config["electricity"]["demand"]["disaggregation"]
+def demand_dissagregate_data(wildcards):
+    end_use = wildcards.end_use
+    if end_use == "power":
+        strategy = "pop"
+    else:
+        strategy = config["sector"]["demand"]["disaggregation"][end_use]
+
     if strategy == "pop":
         return ""
     elif strategy == "cliu":
@@ -235,68 +257,18 @@ def electricty_study_dissagregate(wildcards):
         return ""
 
 
-def sector_study_demand(wildcards):
+def demand_scaling_data(wildcards):
+
     end_use = wildcards.end_use
-    profile = config["sector"]["demand"]["profile"][end_use]
-    if end_use == "residential":
-        if profile == "eulp":
-            return [
-                DATA + f"eulp/res/{state}.csv"
-                for state in INTERCONNECT_2_STATE[wildcards.interconnect]
-            ]
-        elif profile == "efs":
-            return DATA + "nrel_efs/EFSLoadProfile_Reference_Moderate.csv"
-        else:
-            return ""
-    elif end_use == "commercial":
-        if profile == "eulp":
-            return [
-                DATA + f"eulp/com/{state}.csv"
-                for state in INTERCONNECT_2_STATE[wildcards.interconnect]
-            ]
-        elif profile == "efs":
-            return DATA + "nrel_efs/EFSLoadProfile_Reference_Moderate.csv"
-        else:
-            return ""
-    elif end_use == "industry":
-        if profile == "efs":
-            return DATA + "nrel_efs/EFSLoadProfile_Reference_Moderate.csv"
-        elif profile == "cliu":
-            return [
-                DATA + "industry_load/2014_update_20170910-0116.csv",  # cliu data
-                DATA + "industry_load/epri_industrial_loads.csv",  # epri data
-                DATA + "industry_load/table3_2.xlsx",  # mecs data
-                DATA + "industry_load/fips_codes.csv",  # fips data
-            ]
-        else:
-            return ""
-    elif end_use == "transport":
-        if profile == "efs":
-            return DATA + "nrel_efs/EFSLoadProfile_Reference_Moderate.csv"
-        else:
-            return ""
+    if end_use == "power":
+        profile = config["electricity"]["demand"]["profile"]
     else:
-        return ""
+        profile = config["sector"]["demand"]["profile"][end_use]
 
-
-def sector_study_dissagregate(wildcards):
-    end_use = wildcards.end_use
-    strategy = config["sector"]["demand"]["disaggregation"][end_use]
-    if end_use == "residential":
-        if strategy == "pop":
-            return ""
-    elif end_use == "commercial":
-        if strategy == "pop":
-            return ""
-    elif end_use == "industry":
-        if strategy == "pop":
-            return ""
-        elif strategy == "cliu":
-            return DATA + "industry_load/2014_update_20170910-0116.csv"
-        else:
-            return ""
-    elif end_use == "transport":
-        return ""
+    if profile == "efs":
+        return DATA + "nrel_efs/EFSLoadProfile_Reference_Moderate.csv"
+    elif profile == "eia":
+        return DATA + "pudl/pudl.sqlite"
     else:
         return ""
 
@@ -310,8 +282,8 @@ rule build_electrical_demand:
         profile_year=pd.to_datetime(config["snapshots"]["start"]).year,
     input:
         network=RESOURCES + "{interconnect}/elec_base_network.nc",
-        demand_files=electricty_study_demand,
-        pudl=DATA + "pudl/pudl.sqlite",
+        demand_files=demand_raw_data,
+        demand_scaling_file=demand_scaling_data,
     output:
         elec_demand=RESOURCES + "{interconnect}/{end_use}_electricity_demand.csv",
     log:
@@ -335,8 +307,9 @@ rule build_sector_demand:
         eia_api=config["api"]["eia"],
     input:
         network=RESOURCES + "{interconnect}/elec_base_network.nc",
-        demand_files=sector_study_demand,
-        county_industrial_energy=DATA + "industry_load/2014_update_20170910-0116.csv",
+        demand_files=demand_raw_data,
+        dissagregate_files=demand_dissagregate_data,
+        demand_scaling_file=demand_scaling_data,
     output:
         elec_demand=RESOURCES + "{interconnect}/{end_use}_electricity_demand.csv",
         heat_demand=RESOURCES + "{interconnect}/{end_use}_heating_demand.csv",

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -311,9 +311,7 @@ rule build_electrical_demand:
     input:
         network=RESOURCES + "{interconnect}/elec_base_network.nc",
         demand_files=electricty_study_demand,
-        eia=expand(DATA + "GridEmissions/{file}", file=DATAFILES_GE),
-        efs=DATA + "nrel_efs/EFSLoadProfile_Reference_Moderate.csv",
-        county_industrial_energy=DATA + "industry_load/2014_update_20170910-0116.csv",
+        pudl=DATA + "pudl/pudl.sqlite",
     output:
         elec_demand=RESOURCES + "{interconnect}/{end_use}_electricity_demand.csv",
     log:

--- a/workflow/scripts/plot_statistics.py
+++ b/workflow/scripts/plot_statistics.py
@@ -75,16 +75,31 @@ def get_color_palette(n: pypsa.Network) -> dict[str, str]:
     colors = (n.carriers.reset_index().set_index("nice_name")).color
 
     additional = {
-        "Battery Charge": n.carriers.loc["battery"].color,
-        "Battery Discharge": n.carriers.loc["battery"].color,
-        "battery_discharger": n.carriers.loc["battery"].color,
-        "battery_charger": n.carriers.loc["battery"].color,
-        "4hr_battery_storage_discharger": n.carriers.loc["4hr_battery_storage"].color,
-        "4hr_battery_storage_charger": n.carriers.loc["4hr_battery_storage"].color,
-        "8hr_battery_storage_discharger": n.carriers.loc["8hr_battery_storage"].color,
-        "8hr_battery_storage_charger": n.carriers.loc["8hr_battery_storage"].color,
+        "Battery Charge": n.carriers.at["battery", "color"],
+        "Battery Discharge": n.carriers.at["battery", "color"],
+        "battery_discharger": n.carriers.at["battery", "color"],
+        "battery_charger": n.carriers.at["battery", "color"],
         "co2": "k",
     }
+    for hr in ("4", "8"):
+        try:
+            additional[f"{hr}hr_battery_storage_discharger"] = n.carriers.at[
+                f"{hr}hr_battery_storage",
+                "color",
+            ]
+            additional[f"{hr}hr_battery_storage_charger"] = n.carriers.at[
+                f"{hr}hr_battery_storage",
+                "color",
+            ]
+        except KeyError:
+            additional[f"{hr}hr_battery_storage_discharger"] = n.carriers.at[
+                "battery",
+                "color",
+            ]
+            additional[f"{hr}hr_battery_storage_charger"] = n.carriers.at[
+                "battery",
+                "color",
+            ]
 
     return pd.concat([colors, pd.Series(additional)]).to_dict()
 
@@ -1135,10 +1150,10 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "plot_statistics",
-            interconnect="western",
-            clusters=80,
+            interconnect="texas",
+            clusters=20,
             ll="v1.0",
-            opts="Ep-Co2L0.2",
+            opts="500SEG",
             sector="E",
         )
     configure_logging(snakemake)


### PR DESCRIPTION
Closes #339 
Closes #276 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

In this PR I add sacling to demand. Specifically;
- If EIA data is used, data is scaled according to AEO data (now pulled from PUDL). 
- If EFS data is used, data is interpolated between the two closes EFS years
- A Demand Formatter class is added which handles scaling and formatting data, regardless of sector. 
- The demand formatter will instantiate a DemandScaler object which handles logic for scaling specific data

While this is not the most efficient implementation (as, for example, EFS data has to get read in once during the reading/writing, and again for scaling), I beleive this is clearer and more maintainable for our current workload. But happy to discuss this point! :) 

This PR also removes the option of selecting scaling method in the configuration file, as we should lock this to align data. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
