### PR TITLE
Fix for single period runs

### DIFF
--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -1120,10 +1120,8 @@ def solve_network(n, config, solving, opts="", **kwargs):
     set_of_options = solving["solver"]["options"]
     cf_solving = solving["options"]
 
-    # if len(n.investment_periods) > 1:
-    #     kwargs["multi_investment_periods"] = config["foresight"] == "perfect"
-
-    kwargs["multi_investment_periods"] = config["foresight"] == "perfect"
+    if len(n.investment_periods) > 1:
+        kwargs["multi_investment_periods"] = config["foresight"] == "perfect"
 
     kwargs["solver_options"] = (
         solving["solver_options"][set_of_options] if set_of_options else {}


### PR DESCRIPTION
Closes #413 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

In this PR I have made the `multi_investment_period` option activated for solving, only when multi-period investment scenarios are run. This was causing a Linopy building error before. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
