### PR TITLE
Service sector standing losses

### DIFF
--- a/workflow/repo_data/config/config.sector.yaml
+++ b/workflow/repo_data/config/config.sector.yaml
@@ -1,6 +1,3 @@
-# sector coupling studies 
-
-# docs :
 sector:
   co2:
     sequestration_potential: 0
@@ -13,18 +10,15 @@ sector:
     gwp: 18 # to be implemented 
   heating:
     heat_pump_sink_T: 55.
-    standing_loss_space: 0
-    standing_loss_water: 0.032
   service_sector:
-    dynamic_costs: True # false to be implemented 
+    dynamic_costs: True
     split_res_com: True # false to be implemented 
-    split_urban_rural: True # false to be implemented 
-    split_space_water_heating: True # false to be implemented 
+    split_urban_rural: False
+    split_space_water_heating: True
     brownfield: True
     gas_connection:
       rural: 1 # to be implemented
       urban: 1 # to be implemented
-      total: 1 # to be implemented
     technologies:
       space_heating:
         elec_furnace: true
@@ -32,13 +26,14 @@ sector:
         oil_furnace: true
         heat_pump: true
         air_con: true
-      water_heating: # false to be implemented
-        elec_water_tank: false # true to be implemented
-        elec_instant: false # true to be implemented
+      water_heating: 
+        elec_water_tank: true 
         gas_water_tank: true
-        gas_instant: true
         oil_water_tank: true
-    loads:
+      standing_losses: # per-unit
+        space: 0.05
+        water: 0.01
+    loads: # to be implemented 
       heating: true
       cooling: true
   transport_sector:
@@ -58,5 +53,3 @@ sector:
       gas_furnace: true
       coal_furnace: true
       heat_pump: true
-  
-    


### PR DESCRIPTION
Closes #403 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->
In this PR I correct the service sector standing loss configuration option. Losses can be applied for both space and water heating; or just via space heating if space/water is not separated. Looses are applied as a per-unit per-hour loss. 

This is a little different than the PyPSA-Eur implementation. They input this as a time constant and calculate the loss via a decay function; may be worth looking into this in the future. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
