### PR TITLE
Implements mixed resolution aggregations

### DIFF
--- a/workflow/repo_data/config/config.common.yaml
+++ b/workflow/repo_data/config/config.common.yaml
@@ -130,11 +130,6 @@ lines:
     500.: "Al/St 560/50 4-bundle 750.0"
     765.: "Al/St 560/50 4-bundle 750.0"
 
-model_topology:
-  interface_transmission_limits: false
-  topological_boundaries: 'reeds_zone' # [reeds_zone]
-
-
 # docs :
 offshore_shape:
   use: eez #options are ca_osw, eez

--- a/workflow/repo_data/config/config.default.yaml
+++ b/workflow/repo_data/config/config.default.yaml
@@ -21,10 +21,15 @@ scenario:
 # docs :
 model_topology:
   transmission_network: 'reeds' # [reeds, tamu]
+  topological_boundaries: 'county' # [county, reeds_zone]
+  interface_transmission_limits: false
   include: # mixed zone types not supported
-    reeds_zone: ['p62']
+    # reeds_zone: ['p62']
     # reeds_state: ['CO']
     # reeds_ba: ['ERCO']
+  aggregate: # [reeds_zone, trans_reg]
+    # trans_grp: []
+    # reeds_zone: []
 
 # docs :
 enable:

--- a/workflow/repo_data/config/config.tutorial.yaml
+++ b/workflow/repo_data/config/config.tutorial.yaml
@@ -21,10 +21,16 @@ scenario:
 # docs :
 model_topology:
   transmission_network: 'tamu' # [reeds, tamu]
+  topological_boundaries: 'county' # [county, reeds_zone]
+  interface_transmission_limits: false
   include: # mixed zone types not supported
-    # reeds_zone: ['p63']
-    # reeds_state: ['CO']
-    # reeds_ba: ['ERCO']
+    # reeds_zone: []
+    # reeds_state: []
+    # reeds_ba: []
+  aggregate: # [reeds_zone, trans_reg]
+    # trans_grp: []
+    # reeds_zone: []
+
 
 # docs :
 enable:

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -680,7 +680,7 @@ rule cluster_network:
         + f"costs/costs_{config['scenario']['planning_horizons'][0]}.csv",
         itl_reeds_zone="repo_data/ReEDS_Constraints/transmission/transmission_capacity_init_AC_ba_NARIS2024.csv",
         itl_county="repo_data/ReEDS_Constraints/transmission/transmission_capacity_init_AC_county_NARIS2024.csv",
-        itl_trans_reg="repo_data/ReEDS_Constraints/transmission/transmission_capacity_init_AC_transgrp_NARIS2024.csv",
+        itl_trans_grp="repo_data/ReEDS_Constraints/transmission/transmission_capacity_init_AC_transgrp_NARIS2024.csv",
         itl_costs_reeds_zone="repo_data/ReEDS_Constraints/transmission/transmission_distance_cost_500kVdc_ba.csv",
         itl_costs_county="repo_data/ReEDS_Constraints/transmission/transmission_distance_cost_500kVac_county.csv",
     output:

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -597,6 +597,7 @@ rule add_electricity:
         regions_onshore=RESOURCES + "{interconnect}/Geospatial/regions_onshore.geojson",
         regions_offshore=RESOURCES
         + "{interconnect}/Geospatial/regions_offshore.geojson",
+        reeds_shapes=RESOURCES + "{interconnect}/Geospatial/reeds_shapes.geojson",
         powerplants=RESOURCES + "powerplants.csv",
         plants_eia="repo_data/plants/plants_merged.csv",
         plants_breakthrough=DATA + "breakthrough_network/base_grid/plant.csv",

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -664,6 +664,7 @@ rule cluster_network:
         topological_boundaries=config_provider(
             "model_topology", "topological_boundaries"
         ),
+        topology_aggregation=config_provider("model_topology", "aggregate"),
     input:
         network=RESOURCES + "{interconnect}/elec_s{simpl}.nc",
         regions_onshore=RESOURCES
@@ -677,10 +678,11 @@ rule cluster_network:
         ),
         tech_costs=RESOURCES
         + f"costs/costs_{config['scenario']['planning_horizons'][0]}.csv",
-        itl_ba="repo_data/ReEDS_Constraints/transmission/transmission_capacity_init_AC_ba_NARIS2024.csv",
+        itl_reeds_zone="repo_data/ReEDS_Constraints/transmission/transmission_capacity_init_AC_ba_NARIS2024.csv",
         itl_county="repo_data/ReEDS_Constraints/transmission/transmission_capacity_init_AC_county_NARIS2024.csv",
-        itl_costs_ba="repo_data/ReEDS_Constraints/transmission/transmission_distance_cost_500kVdc_ba.csv",
-        itl_costs_county="repo_data/ReEDS_Constraints/transmission/transmission_distance_cost_500kVdc_ba.csv",
+        itl_trans_reg="repo_data/ReEDS_Constraints/transmission/transmission_capacity_init_AC_transgrp_NARIS2024.csv",
+        itl_costs_reeds_zone="repo_data/ReEDS_Constraints/transmission/transmission_distance_cost_500kVdc_ba.csv",
+        itl_costs_county="repo_data/ReEDS_Constraints/transmission/transmission_distance_cost_500kVac_county.csv",
     output:
         network=RESOURCES + "{interconnect}/elec_s{simpl}_c{clusters}.nc",
         regions_onshore=RESOURCES

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -321,6 +321,7 @@ def filter_plants_by_region(
             max_distance=2000,
             distance_col="distance",
         )
+        plants_nearshore = plants_nearshore.to_crs(epsg=4326)
         plants_filt = pd.concat([plants_filt, plants_nearshore])
 
     plants_filt.drop(columns=["geometry"], inplace=True)

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -288,6 +288,7 @@ def filter_plants_by_region(
     plants: pd.DataFrame,
     regions_onshore: gpd.GeoDataFrame,
     regions_offshore: gpd.GeoDataFrame,
+    reeds_shapes: gpd.GeoDataFrame,
 ) -> pd.DataFrame:
     """
     Filters the plants dataframe to remove plants not within the onshore and
@@ -299,15 +300,35 @@ def filter_plants_by_region(
         plants.latitude,
         crs="EPSG:4326",
     )
-    gdp_plants = gpd.GeoDataFrame(plants, geometry="geometry")
-    plants_onshore = gpd.sjoin(gdp_plants, regions_onshore, how="inner")
-    plants_offshore = gpd.sjoin(gdp_plants, regions_offshore, how="inner")
-    plants = pd.concat([plants_onshore, plants_offshore])
+    gdf_plants = gpd.GeoDataFrame(plants, geometry="geometry")
+    plants_onshore = gpd.sjoin(gdf_plants, regions_onshore, how="inner")
+    plants_offshore = gpd.sjoin(gdf_plants, regions_offshore, how="inner")
     if not plants_offshore.empty:
         logger.warning(f"Offshore plants: {plants_offshore}")
-    plants.drop(columns=["geometry"], inplace=True)
-    plants = plants[~plants.index.duplicated()]
-    return pd.DataFrame(plants)
+    plants_filt = pd.concat([plants_onshore, plants_offshore])
+
+    # Some plants like Diablo Canyon near oceans don't have region due to
+    # imprecise ReEDS Shapes. We filter plants that have no reeds regions,
+    # then search these points again.
+    plants_in_regions = gpd.sjoin(gdf_plants, reeds_shapes, how="inner", predicate="intersects")
+    plants_no_region = gdf_plants[~gdf_plants.index.isin(plants_in_regions.index)]
+    if not plants_no_region.empty:
+        plants_no_region = plants_no_region.to_crs(epsg=3857)
+        plants_nearshore = gpd.sjoin_nearest(
+            plants_no_region,
+            regions_onshore.to_crs(epsg=3857),
+            how="inner",
+            max_distance=2000,
+            distance_col="distance",
+        )
+        plants_filt = pd.concat([plants_filt, plants_nearshore])
+
+    plants_filt.drop(columns=["geometry"], inplace=True)
+    plants_filt = plants_filt[~plants_filt.index.duplicated()]
+
+    plants_filt[plants_filt.index.str.contains("Diablo")]
+    gdf_plants[gdf_plants.index.str.contains("Diablo")]
+    return pd.DataFrame(plants_filt)
 
 
 def attach_renewable_capacities_to_atlite(
@@ -765,6 +786,7 @@ def main(snakemake):
 
     regions_onshore = gpd.read_file(snakemake.input.regions_onshore)
     regions_offshore = gpd.read_file(snakemake.input.regions_offshore)
+    reeds_shapes = gpd.read_file(snakemake.input.reeds_shapes)
 
     Nyears = n.snapshot_weightings.loc[n.investment_periods[0]].objective.sum() / 8760.0
 
@@ -787,6 +809,7 @@ def main(snakemake):
         plants,
         regions_onshore,
         regions_offshore,
+        reeds_shapes,
     )
     plants = match_plant_to_bus(n, plants)
 

--- a/workflow/scripts/add_extra_components.py
+++ b/workflow/scripts/add_extra_components.py
@@ -579,7 +579,7 @@ if __name__ == "__main__":
     apply_max_annual_growth_rate(n, snakemake.config["costs"]["max_growth"])
     add_nice_carrier_names(n, snakemake.config)
     add_co2_emissions(n, costs_dict[n.investment_periods[0]], n.carriers.index)
-    n.generators.to_csv("generators_ec.csv")
+    # n.generators.to_csv("generators_ec.csv")
     n.consistency_check()
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
     n.export_to_netcdf(snakemake.output[0])

--- a/workflow/scripts/build_base_network.py
+++ b/workflow/scripts/build_base_network.py
@@ -502,6 +502,23 @@ def assign_reeds_memberships(n: pypsa.Network, fn_reeds_memberships: str):
     n.buses["trans_grp"] = n.buses.reeds_zone.map(reeds_memberships.transgrp)
     n.buses["reeds_state"] = n.buses.reeds_zone.map(reeds_memberships.st)
 
+    # Groupby county, and assign the most common reeds_zone, reeds_ba, reeds_state, nerc
+    # This is a fix for the few counties that are split between unaligned county GIS and Reeds Zone Shapes.
+    n.buses["reeds_zone"] = n.buses.groupby("county")["reeds_zone"].transform(lambda x: x.mode()[0])
+    n.buses["reeds_ba"] = n.buses.groupby("county")["reeds_ba"].transform(lambda x: x.mode()[0])
+    n.buses["reeds_state"] = n.buses.groupby("county")["reeds_state"].transform(lambda x: x.mode()[0])
+    n.buses["nerc_reg"] = n.buses.groupby("county")["nerc_reg"].transform(lambda x: x.mode()[0])
+    n.buses["trans_reg"] = n.buses.groupby("county")["trans_reg"].transform(lambda x: x.mode()[0])
+    n.buses["trans_grp"] = n.buses.groupby("county")["trans_grp"].transform(lambda x: x.mode()[0])
+
+    # # Assert that each county must have the same reeds_ba, reeds_zone, reeds_state, nerc_reg, and trans_reg
+    # assert n.buses.groupby("county")["reeds_ba"].nunique().eq(1).all()
+    # assert n.buses.groupby("county")["reeds_zone"].nunique().eq(1).all()
+    # assert n.buses.groupby("county")["reeds_state"].nunique().eq(1).all()
+    # assert n.buses.groupby("county")["nerc_reg"].nunique().eq(1).all()
+    # assert n.buses.groupby("county")["trans_reg"].nunique().eq(1).all()
+    # assert n.buses.groupby("county")["trans_grp"].nunique().eq(1).all()
+
 
 def modify_breakthrough_substations(buslocs: pd.DataFrame):
     sub_fixes = {
@@ -515,6 +532,13 @@ def modify_breakthrough_substations(buslocs: pd.DataFrame):
         35116: {"lon": -122.462, "lat": 48.982},
         37707: {"lon": -115.4550, "lat": 32.6866},
         35976: {"lon": -120.8735, "lat": 39.4691},
+        39211: {"lon": -104.6295, "lat": 39.3372},
+        38886: {"lon": -106.5569, "lat": 31.8004},
+        39574: {"lon": -115.0836, "lat": 42.8692},
+        39547: {"lon": -113.4500, "lat": 42.6942},
+        38928: {"lon": -108.0648, "lat": 39.0692},
+        39570: {"lon": -114.3526, "lat": 42.6286},
+        39571: {"lon": -114.0353, "lat": 42.5435},
     }
     for i in sub_fixes.keys():
         buslocs.loc[buslocs.sub_id == i, "lon"] = sub_fixes[i]["lon"]

--- a/workflow/scripts/build_base_network.py
+++ b/workflow/scripts/build_base_network.py
@@ -499,6 +499,7 @@ def assign_reeds_memberships(n: pypsa.Network, fn_reeds_memberships: str):
     reeds_memberships = pd.read_csv(fn_reeds_memberships, index_col=0)
     n.buses["nerc_reg"] = n.buses.reeds_zone.map(reeds_memberships.nercr)
     n.buses["trans_reg"] = n.buses.reeds_zone.map(reeds_memberships.transreg)
+    n.buses["trans_grp"] = n.buses.reeds_zone.map(reeds_memberships.transgrp)
     n.buses["reeds_state"] = n.buses.reeds_zone.map(reeds_memberships.st)
 
 

--- a/workflow/scripts/cluster_network.py
+++ b/workflow/scripts/cluster_network.py
@@ -562,12 +562,14 @@ def convert_to_transport(
         itl_agg = pd.concat([itl_agg, itls_to_virtual])
         itl_agg_costs = None if itl_agg_costs_fn is None else pd.read_csv(itl_agg_costs_fn)
         add_itls(buses, itl_agg, itl_agg_costs, expansion=False)
+        itls = pd.concat([itls_filt, itl_agg])
+    else:
+        itls = itls_filt
 
     clustering.network.add("Carrier", "AC_trans", co2_emissions=0)
     logger.info(f"Replaced Lines with Links for zonal model configuration.")
 
     # Remove any disconnected buses
-    itls = pd.concat([itls_filt, itl_agg])
     unique_buses = buses.loc[itls.r].index.union(buses.loc[itls.rr].index).unique()
     disconnected_buses = clustering.network.buses.index[~clustering.network.buses.index.isin(unique_buses)]
     if len(disconnected_buses) > 0:

--- a/workflow/scripts/simplify_network.py
+++ b/workflow/scripts/simplify_network.py
@@ -166,7 +166,8 @@ def aggregate_to_substations(
             "reeds_ba",
             "nerc_reg",
             "trans_reg",
-            "trans_grp" "reeds_state",
+            "trans_grp",
+            "reeds_state",
         ]
     else:
         cols2drop = ["balancing_area", "substation_off", "sub_id", "state"]

--- a/workflow/scripts/simplify_network.py
+++ b/workflow/scripts/simplify_network.py
@@ -166,7 +166,7 @@ def aggregate_to_substations(
             "reeds_ba",
             "nerc_reg",
             "trans_reg",
-            "reeds_state",
+            "trans_grp" "reeds_state",
         ]
     else:
         cols2drop = ["balancing_area", "substation_off", "sub_id", "state"]


### PR DESCRIPTION
## Changes proposed in this Pull Request
Within model_topology- user can now build networks that mesh multiple spatial scales.

```yaml
model_topology:
  transmission_network: 'reeds' # [reeds, tamu]
  topological_boundaries: 'reeds_zone' # [county, reeds_zone]
  interface_transmission_limits: false
  include: # mixed zone types not supported
    # reeds_zone: ['p8']
    reeds_state: ['CA']
    # reeds_ba: ['ERCO']
  aggregate: # eligible keys: [reeds_zone, trans_reg]
    # trans_grp: []
    # reeds_zone: []
```
- Fixes bug with ReEDS Shapes where imprecise ReEDS GIS files leads to small number of ocean-side plants being dropped.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
