### PR TITLE
Fix natural gas storage constraint

### DIFF
--- a/workflow/scripts/build_natural_gas.py
+++ b/workflow/scripts/build_natural_gas.py
@@ -348,6 +348,10 @@ class GasStorage(GasData):
                 "state": "STATE",
             },
         )
+        # REVIST THIS
+        # start storage a 2/3 full
+        df["e_initial"] = df.MIN_CAPACITY_MWH + (df.MAX_CAPACITY_MWH - df.MIN_CAPACITY_MWH).div(1.5)
+
         return self.filter_on_interconnect(df, ["U.S."])
 
     def filter_on_sate(
@@ -401,7 +405,8 @@ class GasStorage(GasData):
             e_nom=df.MAX_CAPACITY_MWH,
             e_cyclic=cyclic_storage,
             e_min_pu=df.MIN_CAPACITY_MWH / df.MAX_CAPACITY_MWH,
-            e_initial=df.MAX_CAPACITY_MWH - df.MIN_CAPACITY_MWH,  # same as working
+            # e_initial=df.MAX_CAPACITY_MWH - df.MIN_CAPACITY_MWH,
+            e_initial=df.e_initial,
             marginal_cost=0,  # to update
         )
 
@@ -498,7 +503,12 @@ class GasProcessing(GasData):
         p_nom_max_mult = capacity_mult
 
         if "gas production" not in n.carriers.index:
-            n.add("Carrier", "gas production", color="#d35050", nice_name="Gas Production")
+            n.add(
+                "Carrier",
+                "gas production",
+                color="#d35050",
+                nice_name="Gas Production",
+            )
 
         n.madd(
             "Bus",


### PR DESCRIPTION
Closes #452 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->
In this PR I correct the underground storage e_initial values for natural gas. Right now just a hardcoded value of starting the year at 2/3 full is done to get this working (a rough estimate from [here](https://www.eia.gov/dnav/ng/ng_stor_wkly_s1_w.htm)). This should get corrected to pull actual values though. 

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
