### PR TITLE
Minor Changes to historical fuel costs assignments, and matching reeds topology modifications

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -72,7 +72,7 @@ localrules:
 wildcard_constraints:
     interconnect="usa|texas|western|eastern",
     simpl="[a-zA-Z0-9]*|all",
-    clusters="[0-9]+m?|all",
+    clusters="[0-9]+m?+c?|all",
     ll="(v|c)([0-9\.]+|opt|all)|all",
     opts="[-+a-zA-Z0-9\.]*",
     sector="([EG]-)*[EG]",

--- a/workflow/scripts/build_fuel_prices.py
+++ b/workflow/scripts/build_fuel_prices.py
@@ -157,7 +157,10 @@ def build_pudl_fuel_costs(snapshots: pd.DatetimeIndex, start_date: str, end_date
     fuel_cost_temporal["interconnect"] = fuel_cost_temporal["nerc_region"].map(
         const.NERC_REGION_MAPPER,
     )
-    fuel_cost_temporal = fuel_cost_temporal[fuel_cost_temporal["interconnect"] == snakemake.wildcards.interconnect]
+    
+    if snakemake.wildcards.interconnect != 'usa':
+        fuel_cost_temporal = fuel_cost_temporal[fuel_cost_temporal["interconnect"] == snakemake.wildcards.interconnect]
+    
     fuel_cost_temporal["generator_name"] = (
         fuel_cost_temporal["plant_name_eia"].astype(str)
         + "_"

--- a/workflow/scripts/build_powerplants.py
+++ b/workflow/scripts/build_powerplants.py
@@ -689,6 +689,11 @@ def set_parameters(plants: pd.DataFrame):
     plants.loc[plants.fuel_type.isin(zero_mc_fuel_types), "fuel_cost"] = 0
     plants = impute_missing_plant_data(
         plants,
+        ["state", "fuel_name"],
+        ["fuel_cost"],
+    )
+    plants = impute_missing_plant_data(
+        plants,
         ["balancing_authority_code_eia", "fuel_name"],
         ["fuel_cost"],
     )
@@ -697,11 +702,11 @@ def set_parameters(plants: pd.DataFrame):
         ["nerc_region", "fuel_name"],
         ["fuel_cost"],
     )
-    plants = impute_missing_plant_data(
-        plants,
-        ["nerc_region", "technology_description"],
-        ["fuel_cost"],
-    )
+    # plants = impute_missing_plant_data(
+    #     plants,
+    #     ["nerc_region", "technology_description"],
+    #     ["fuel_cost"],
+    # )
     plants = impute_missing_plant_data(plants, ["fuel_name"], ["fuel_cost"])
     plants = impute_missing_plant_data(plants, ["prime_mover_code"], ["fuel_cost"])
     plants.loc[plants.carrier.isin(["nuclear"]), "fuel_cost"] = 0.7
@@ -743,7 +748,7 @@ def set_parameters(plants: pd.DataFrame):
 
     plants = impute_missing_plant_data(
         plants,
-        ["nerc_region", "prime_mover_code", "fuel_type"],
+        ["nerc_region", "prime_mover_code"],
         ["heat_rate"],
     )
     plants = impute_missing_plant_data(

--- a/workflow/scripts/cluster_network.py
+++ b/workflow/scripts/cluster_network.py
@@ -509,6 +509,25 @@ def convert_to_transport(
         logger.warning(
             f"Network configuration contains {len(disconnected_buses)} disconnected buses. ",
         )
+
+    # Dissolve TX for particular zones according to default reeds configurations
+    clustering.network.links.loc[clustering.network.links.bus0.isin(['p119']) & clustering.network.links.bus1.isin(['p122']), 'p_nom'] = 1e9
+    clustering.network.links.loc[clustering.network.links.bus1.isin(['p119']) & clustering.network.links.bus0.isin(['p122']), 'p_nom'] = 1e9   
+    # Dissolve p124 and p99
+    if "p124" in clustering.network.buses.index and "p99" in clustering.network.buses.index:
+        clustering.network.add(
+            "Link",
+            "p124||p99",
+            bus0="p124",
+            bus1="p99",
+            p_nom=1e9,
+            p_nom_extendable=False,
+            length=0,
+            capital_cost=0,
+            efficiency=1,
+            carrier="AC",
+        )
+
     return clustering
 
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Simplifies historical PUDL fuel cost imputations. Switches to using the fuel_cost_per_mmbtu to combine with the unit heat rates
- Increases the link capacities for a few links to match the configuration settings in ReEDS: (https://nrel.github.io/ReEDS-2.0/faq.html#is-there-a-way-to-reduce-solve-time)
- Adds a check in add_electricity to ensure plants are assigned to the correct State. This shouldn't impact many plants, but there were corner cases if plants were located right at the border of a State where they could be mis-assigned to their neighboring state.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
