### PR TITLE
Correct NG capacity 

### DIFF
--- a/workflow/repo_data/config/config.sector.yaml
+++ b/workflow/repo_data/config/config.sector.yaml
@@ -4,11 +4,11 @@ sector:
     policy: "config/policy_constraints/sector_co2_limits.csv"
   natural_gas:
     imports:
-      min: 0.9
-      max: 1.1
+      min: 0.99
+      max: 1.01
     exports:
-      min: 0.9
-      max: 1.1
+      min: 0.99
+      max: 1.01
     cyclic_storage: true
     standing_loss: 0
   methane:

--- a/workflow/rules/build_sector.smk
+++ b/workflow/rules/build_sector.smk
@@ -13,7 +13,7 @@ def sector_input_files(wildcards):
         ng_files = {
             "county": DATA + "counties/cb_2020_us_county_500k.shp",
             "pipeline_capacity": DATA
-            + "natural_gas/EIA-StatetoStateCapacity_Jan2023.xlsx",
+            + "natural_gas/EIA-StatetoStateCapacity_Feb2024.xlsx",
             "pipeline_shape": DATA + "natural_gas/pipelines.geojson",
             "eia_757": DATA + "natural_gas/EIA-757.csv",
             "cop_soil_total": RESOURCES

--- a/workflow/rules/retrieve.smk
+++ b/workflow/rules/retrieve.smk
@@ -33,7 +33,7 @@ def define_zenodo_databundles():
 
 def define_sector_databundles():
     return {
-        "pypsa_usa_sec": "https://zenodo.org/records/11358880/files/pypsa_usa_sector_data.zip"
+        "pypsa_usa_sec": "https://zenodo.org/records/14291626/files/pypsa_usa_sector_data.zip"
     }
 
 
@@ -78,6 +78,7 @@ sector_datafiles = [
     # natural gas
     "natural_gas/EIA-757.csv",
     "natural_gas/EIA-StatetoStateCapacity_Jan2023.xlsx",
+    "natural_gas/EIA-StatetoStateCapacity_Feb2024.xlsx",
     "natural_gas/pipelines.geojson",
     # industrial demand
     "industry_load/2014_update_20170910-0116.csv",

--- a/workflow/scripts/build_natural_gas.py
+++ b/workflow/scripts/build_natural_gas.py
@@ -627,6 +627,9 @@ class _GasPipelineCapacity(GasData):
             trade = self._get_capacity_based_on_trade_flows()
             df = self._merge_capacity_trade_data(df, trade)
 
+        # slight buffer for when building constraints
+        df["CAPACITY_MW"] = np.ceil(df["CAPACITY_MW"].mul(1.02))
+
         return self.extract_pipelines(df)
 
     def _get_capacity_based_on_trade_flows(self) -> pd.DataFrame:


### PR DESCRIPTION
Closes #487,
Closes #438  

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->
In this PR I add logic to correct pipeline capacity. As described in issue #487, the annual trade values do not necessarily respect design limits on pipeline capacity. This PR combines the two datasets to get the max capacity between the two. Also, the capacity dataset has been updated to 2024 data. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
