### PR TITLE
Implements h2-ct formulation

### DIFF
--- a/workflow/repo_data/config/config.default.yaml
+++ b/workflow/repo_data/config/config.default.yaml
@@ -63,7 +63,7 @@ electricity:
     H2: 168
 
   extendable_carriers:
-    Generator: [solar, onwind, offwind_floating, OCGT, CCGT, CCGT-95CCS, coal, nuclear] #include CCGT-CCS
+    Generator: [solar, onwind, offwind_floating, OCGT, CCGT, CCGT-95CCS, coal, nuclear, hydrogen-ct] #include CCGT-CCS
     StorageUnit: [4hr_battery_storage, 8hr_battery_storage] # [Xhr-battery-storage (2-10 hours)]
     Store: []
     Link: [] 

--- a/workflow/repo_data/config/config.default.yaml
+++ b/workflow/repo_data/config/config.default.yaml
@@ -131,6 +131,8 @@ costs:
     8hr_PHS: 0.3
     10hr_PHS: 0.3
     12hr_PHS: 0.3
+  min_year: # {carrier: year}
+    hydrogen_ct: 2040
   max_growth: # {carrier: {base:, rate:}}
 
 # docs :

--- a/workflow/repo_data/config/config.plotting.yaml
+++ b/workflow/repo_data/config/config.plotting.yaml
@@ -6,12 +6,6 @@ plotting:
   energy_min: -10000.
   energy_threshold: 50.
 
-  # vre_techs: ["onwind","offwind_floating", "offwind-ac", "offwind-dc", "solar", "ror"]
-  # conv_techs: ["OCGT", "CCGT", "Nuclear", "Coal"]
-  # storage_techs: ["hydro+PHS", "battery", "H2"]
-  # load_carriers: ["AC load"]
-  # AC_carriers: ["AC line", "AC transformer"]
-  # link_carriers: ["DC line", "Converter AC-DC"]
   tech_colors:
     "onwind": "#235ebc"
     "wind": "#235ebc"
@@ -90,6 +84,8 @@ plotting:
     "8hr_PHS_charger": "#069686"
     "10hr_PHS_charger": "#058a79"
     "12hr_PHS_charger": "#047d6c"  
+    "hydrogen-ct": "#ea048a"
+
 
     # sector studies only 
 
@@ -258,6 +254,7 @@ plotting:
     lines: "Transmission Lines"
     ror: "Run of River"
     Load: "Load Shed"
+    hydrogen-ct: "Hydrogen Combustion Turbine"
 
     # sector studies only 
 

--- a/workflow/scripts/add_extra_components.py
+++ b/workflow/scripts/add_extra_components.py
@@ -433,9 +433,12 @@ def attach_newCarrier_generators(n, costs, carriers, investment_year):
 
     add_missing_carriers(n, carriers)
     add_co2_emissions(n, costs, carriers)
-
+    min_years = snakemake.config["costs"].get("min_year")
     buses_i = n.buses.index
     for carrier in carriers:
+        if min_years and min_years.get(carrier, np.inf) > investment_year:
+            continue
+
         n.madd(
             "Generator",
             buses_i,

--- a/workflow/scripts/build_cost_data.py
+++ b/workflow/scripts/build_cost_data.py
@@ -445,6 +445,20 @@ if __name__ == "__main__":
         values="value",
     ).reset_index()
 
+    # Create Hydrogen Combustion Turbine from OCGT using assumptions per ReEDS
+    # https://nrel.github.io/ReEDS-2.0/model_documentation.html#hydrogen
+    hydrogen_ct = pivot_atb[pivot_atb["pypsa-name"] == "OCGT"].copy()
+    hydrogen_ct["pypsa-name"] = "hydrogen_ct"
+    hydrogen_ct["capex_overnight_per_kw"] *= 1.2
+    hydrogen_ct["capex_per_kw"] = (
+        (hydrogen_ct["capex_overnight_per_kw"] + hydrogen_ct["capex_grid_connection_per_kw"])
+        * hydrogen_ct["capex_construction_finance_factor"]
+        / 100
+    )
+    hydrogen_ct["fuel_cost_real_per_mwhth"] = 20 * 3.412  # 20 USD/MMBtu * 3.412 MMBtu/MWh_th
+    hydrogen_ct["co2_emissions"] = 0
+    pivot_atb = pd.concat([pivot_atb, hydrogen_ct], ignore_index=True)
+
     pivot_atb["efficiency"] = 3.412 / pivot_atb["heat_rate_mmbtu_per_mwh"]
     pivot_atb["fuel_cost"] = pivot_atb["fuel_cost_real_per_mwhth"] / pivot_atb["efficiency"]
     pivot_atb["marginal_cost"] = pivot_atb["opex_variable_per_mwh"] + pivot_atb["fuel_cost"]

--- a/workflow/scripts/cluster_network.py
+++ b/workflow/scripts/cluster_network.py
@@ -683,6 +683,8 @@ if __name__ == "__main__":
                     n.buses.loc[agg_busmap.index, "reeds_ba"] = "na"
                     n.buses.loc[agg_busmap.index, "reeds_state"] = "na"
                     n.buses.loc[agg_busmap.index, "county"] = "na"
+                if key == "reeds_zone":
+                    n.buses.loc[agg_busmap.index, "county"] = "na"
                 itl_agg_fn = snakemake.input[f"itl_{key}"]
                 itl_agg_costs_fn = snakemake.input.get(f"itl_costs_{key}", None)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Implements new `hydrogen_ct` technology carrier using assumptions from ReEDS: https://nrel.github.io/ReEDS-2.0/model_documentation.html#hydrogen

- Assumes market purchase of zero carbon H2 which can be utilized in combustion turbine, uses default cost assumption from reeds ($20/MMbtu)
- New `min_year` configuration precludes build of hydrogen_ct to after 2040


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
