### PR TITLE
Corrects TCT constraint 

### DIFF
--- a/docs/source/config-wildcards.md
+++ b/docs/source/config-wildcards.md
@@ -75,6 +75,10 @@ The REM, SAFER, RPS can be defined using either the reeds zone name 'p##"
 the state code (eg, TX, CA, MT), pypsa-usa interconnect name (western, eastern, texas, usa),
 or nerc region name.
 
+```{warning}
+TCT Targets can only be used with renewable generators and utility scale batteries in sector studies.
+```
+
 There are currently:
 
 ```{eval-rst}
@@ -84,13 +88,8 @@ There are currently:
    :file: configtables/opts.csv
 ```
 
-
 (sector)=
 ## The `{sector}` wildcard
-
-```{warning}
-Sector coupling studies are all under active development
-```
 
 The `{sector}` wildcard is used to specify what sectors to include. If `None`
 is provided, an electrical only study is completed.
@@ -100,15 +99,6 @@ is provided, an electrical only study is completed.
 | Electricity | E    | Electrical sector. Will always be run.         | Runs        |
 | Natural Gas | G    | All sectors added                              | Development |
 
-(scope)=
-## The `{scope}` wildcard
-
-```{warning}
-Sector coupling studies are all under active development
-```
-
-Takes values `residential`, `urban`, `total`. Used in sector coupling studies to define
-population breakdown.
 
 (cutout_wc)=
 ## The `{cutout}` wildcard

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -193,7 +193,10 @@ def add_technology_capacity_target_constraints(n, config):
     """
     Add Technology Capacity Target (TCT) constraint to the network.
 
-    Add minimum or maximum levels of generator nominal capacity per carrier for individual regions. Each constraint can be designated for a specified planning horizon in multi-period models. Opts and path for technology_capacity_targets.csv must be defined in config.yaml. Default file is available at config/policy_constraints/technology_capacity_targets.csv.
+    Add minimum or maximum levels of generator nominal capacity per carrier for individual regions.
+    Each constraint can be designated for a specified planning horizon in multi-period models.
+    Opts and path for technology_capacity_targets.csv must be defined in config.yaml.
+    Default file is available at config/policy_constraints/technology_capacity_targets.csv.
 
     Parameters
     ----------
@@ -304,7 +307,7 @@ def add_technology_capacity_target_constraints(n, config):
 
             n.model.add_constraints(
                 lhs >= rhs,
-                name=f"{target.name}_{target.planning_horizon}_min",
+                name=f"GlobalConstraint-{target.name}_{target.planning_horizon}_min",
             )
 
             logger.info(
@@ -327,7 +330,7 @@ def add_technology_capacity_target_constraints(n, config):
 
             n.model.add_constraints(
                 lhs <= rhs,
-                name=f"{target.name}_{target.planning_horizon}_max",
+                name=f"GlobalConstraint-{target.name}_{target.planning_horizon}_max",
             )
 
             logger.info(

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -313,14 +313,15 @@ def add_technology_capacity_target_constraints(n, config):
                 f"Planning Horizon: {target.planning_horizon}\n"
                 f"Region: {target.region}\n"
                 f"Carrier: {target.carrier}\n"
-                f"Min Value: {target['min']}",
+                f"Min Value: {target['min']}\n",
+                f"Min Value Adj: {rhs}",
             )
 
         if not np.isnan(target["max"]):
 
             assert (
                 target["max"] >= lhs_existing
-            ), f"{target['max']} for {target['carrier']} must be at least {lhs_existing}"
+            ), f"TCT constraint of {target['max']} MW for {target['carrier']} must be at least {lhs_existing}"
 
             rhs = target["max"] - round(lhs_existing, 2)
 
@@ -335,7 +336,8 @@ def add_technology_capacity_target_constraints(n, config):
                 f"Planning Horizon: {target.planning_horizon}\n"
                 f"Region: {target.region}\n"
                 f"Carrier: {target.carrier}\n"
-                f"Max Value: {target['max']}",
+                f"Max Value: {target['max']}\n",
+                f"Max Value Adj: {rhs}",
             )
 
 

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -196,8 +196,6 @@ def add_technology_capacity_target_constraints(n, config):
 
     Add minimum or maximum levels of generator nominal capacity per carrier for individual regions. Each constraint can be designated for a specified planning horizon in multi-period models. Opts and path for technology_capacity_targets.csv must be defined in config.yaml. Default file is available at config/policy_constraints/technology_capacity_targets.csv.
 
-    *** Review to subtract the non-extensible capacity from the rhs? ***
-
     Parameters
     ----------
     n : pypsa.Network

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -25,7 +25,6 @@ Additionally, some extra constraints specified in :mod:`solve_network` are added
 
 import logging
 import re
-from math import ceil, floor
 from typing import Any, Optional
 
 import numpy as np
@@ -290,18 +289,18 @@ def add_technology_capacity_target_constraints(n, config):
         lhs_existing = lhs_gens_existing.p_nom.sum() + lhs_storage_existing.p_nom.sum()
 
         if target["max"] == "existing":
-            target["max"] = ceil(lhs_existing)
+            target["max"] = round(lhs_existing, 2) + 0.01
         else:
             target["max"] = float(target["max"])
 
         if target["min"] == "existing":
-            target["min"] = floor(lhs_existing)
+            target["min"] = round(lhs_existing, 2) - 0.01
         else:
             target["min"] = float(target["min"])
 
         if not np.isnan(target["min"]):
 
-            rhs = target["min"] - floor(lhs_existing)
+            rhs = target["min"] - round(lhs_existing, 2)
 
             n.model.add_constraints(
                 lhs >= rhs,
@@ -319,7 +318,11 @@ def add_technology_capacity_target_constraints(n, config):
 
         if not np.isnan(target["max"]):
 
-            rhs = target["max"] - floor(lhs_existing)
+            assert (
+                target["max"] >= lhs_existing
+            ), f"{target['max']} for {target['carrier']} must be at least {lhs_existing}"
+
+            rhs = target["max"] - round(lhs_existing, 2)
 
             n.model.add_constraints(
                 lhs <= rhs,


### PR DESCRIPTION
Closes #520 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

In this PR I update the TCT constraint logic. Specifically, I have removed existing capacity from the rhs of the constraint equation, and left the summation over only extendable generators. 

For example, if there is 10MW of existing solar capacity, and the target is at least 50MW, the constraint will read: 

```
sum(solar_ext_p_nom) >= 40
```

I think to improve interoperability between electricity and sector, it would be nice to not hard code in the `Generator` and `StorageUnit` component filtering, but I will add that as a new issue. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
