### PR TITLE
Updates to cluster configuration

### DIFF
--- a/workflow/repo_data/config/config.cluster.yaml
+++ b/workflow/repo_data/config/config.cluster.yaml
@@ -1,10 +1,10 @@
 __default__:
-  account: iazevedo
-  partition: serc
-  email: ktehranchi@stanford.edu
+  account: 
+  partition: 
+  email: 
   walltime: 00:30:00   # time limit for each job
   cpus_per_task: 1   # number of cores per job
-  chdir: $GROUP_HOME/kamran/pypsa-usa/workflow
+  chdir: 
   output: logs/{rule}/log-%j.out
   error: logs/{rule}/errlog-%j.err
 

--- a/workflow/run_slurm.sh
+++ b/workflow/run_slurm.sh
@@ -1,3 +1,3 @@
 # SLURM specifications made in default.cluster.yaml & the individual rules
 # GRB_LICENSE_FILE=/share/software/user/restricted/gurobi/11.0.2/licenses/gurobi.lic⁠
-snakemake --cluster "sbatch -A {cluster.account} --mail-type ALL -p {cluster.partition} -t {cluster.walltime} -o {cluster.output} -e {cluster.error} -c {threads} --mem {resources.mem_mb}" --cluster-config config/config.cluster.yaml --jobs 10 --latency-wait 60 --configfile config/config.default.yaml
+snakemake --cluster "sbatch -A {cluster.account} -p {cluster.partition} -t {cluster.walltime} -o {cluster.output} -e {cluster.error} -c {threads} --mem {resources.mem_mb}" --cluster-config config/config.cluster.yaml --jobs 10 --latency-wait 60 --configfile config/config.default.yaml

--- a/workflow/run_slurm.sh
+++ b/workflow/run_slurm.sh
@@ -1,3 +1,3 @@
 # SLURM specifications made in default.cluster.yaml & the individual rules
 # GRB_LICENSE_FILE=/share/software/user/restricted/gurobi/11.0.2/licenses/gurobi.lic⁠
-snakemake --cluster "sbatch -A {cluster.account} --mail-type ALL --mail-user {cluster.email} -p {cluster.partition} -t {cluster.walltime} -o {cluster.output} -e {cluster.error} -c {threads} --mem {resources.mem_mb}" --cluster-config config/config.cluster.yaml --jobs 10 --latency-wait 60 --configfile config/base_paper/config.base.yaml
+snakemake --cluster "sbatch -A {cluster.account} --mail-type ALL -p {cluster.partition} -t {cluster.walltime} -o {cluster.output} -e {cluster.error} -c {threads} --mem {resources.mem_mb}" --cluster-config config/config.cluster.yaml --jobs 10 --latency-wait 60 --configfile config/config.default.yaml

--- a/workflow/snakemake_profiles/slurm/config.yaml
+++ b/workflow/snakemake_profiles/slurm/config.yaml
@@ -1,4 +1,4 @@
-cluster: sbatch --partition=serc --cpus-per-task={threads} --mem={resources.mem_mb} --job-name=smk-{rule}-{wildcards} --output=logs/{rule}/{rule}-{wildcards}-%j.out --error=logs/{rule}/{rule}-{wildcards}-.%j.err --mail-type ALL --mail-user ktehranchi@stanford.edu --account=iazevedo --ntasks=1 --nodes=1 --time={resources.walltime}
+cluster: sbatch --partition= --cpus-per-task={threads} --mem={resources.mem_mb} --job-name=smk-{rule}-{wildcards} --output=logs/{rule}/{rule}-{wildcards}-%j.out --error=logs/{rule}/{rule}-{wildcards}-.%j.err --account= --ntasks=1 --nodes=1 --time={resources.walltime}
 default-resources:
 - mem_mb=5000
 - walltime=00:30:00


### PR DESCRIPTION
## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

In this PR I remove any configuration options that are specific to the cluster @ktehranchi is running on. They options remain, but are left blank for users to fill in themselves. The changes include: 
- Removing @ktehranchi's emial 
- Removing the the account `iazevedo`
- Removing the partition `serc`
- Removing the `chdir` path
- Removing the `--mail-type ALL --mail-user {cluster.email}` flag
  - The cluster I run on specifically asks to avoid emails (as per reasons in section 7.1.1 [here](https://docs.alliancecan.ca/wiki/Running_jobs)). But Im not sure if this is a general rule or not 

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
