### PR TITLE
Use zipfile_deflate64 to unzip NREL EFS dataset with windows OS

### DIFF
--- a/workflow/scripts/_helpers.py
+++ b/workflow/scripts/_helpers.py
@@ -3,7 +3,6 @@
 
 import copy
 import hashlib
-import logging
 import re
 from functools import partial
 from pathlib import Path
@@ -97,7 +96,9 @@ def load_network(import_name=None, custom_components=None):
             override_components:
                 ShadowPrice:
                     component: ["shadow_prices","Shadow price for a global constraint.",np.nan]
-                    attributes:
+
+    Attributes
+    ----------
                     name: ["string","n/a","n/a","Unique name","Input (required)"]
                     value: ["float","n/a",0.,"shadow value","Output"]
 
@@ -260,7 +261,6 @@ def aggregate_p_curtailed(n):
 
 
 def aggregate_costs(n, flatten=False, opts=None, existing_only=False):
-
     components = dict(
         Link=("p_nom", "p0"),
         Generator=("p_nom", "p"),
@@ -331,10 +331,6 @@ def get_aggregation_strategies(aggregation_strategies):
 
 
 def export_network_for_gis_mapping(n, output_path):
-    import os
-
-    import pandas as pd
-
     # Creating GIS Table for Mapping Lines in QGIS
     lines_gis = n.lines.copy()
     lines_gis["latitude1"] = n.buses.loc[lines_gis.bus0].y.values
@@ -559,7 +555,6 @@ def update_config_from_wildcards(config, w, inplace=True):
     """
     Parses configuration settings from wildcards and updates the config.
     """
-
     if not inplace:
         config = copy.deepcopy(config)
 
@@ -836,7 +831,6 @@ def get_snapshots(
 
     Taken from PyPSA-Eur implementation
     """
-
     time = pd.date_range(freq=freq, **snapshots, **kwargs)
     if drop_leap_day and time.is_leap_year.any():
         time = time[~((time.month == 2) & (time.day == 29))]

--- a/workflow/scripts/add_demand.py
+++ b/workflow/scripts/add_demand.py
@@ -13,7 +13,6 @@ import pypsa
 from _helpers import (
     configure_logging,
     get_multiindex_snapshots,
-    get_snapshots,
     mock_snakemake,
 )
 from constants_sector import (
@@ -83,7 +82,6 @@ if __name__ == "__main__":
         demand_files = [demand_files]
 
     if sectors == "E" or sectors == "":  # electricity only
-
         assert len(demand_files) == 1
 
         suffix = ""
@@ -91,17 +89,14 @@ if __name__ == "__main__":
 
         df = pd.read_csv(demand_files[0], index_col=0)
         attach_demand(n, df, carrier, suffix)
-        logger.info(f"Electricity demand added to network")
+        logger.info("Electricity demand added to network")
 
     else:  # sector files
-
         for demand_file in demand_files:
-
             parsed_name = Path(demand_file).name.split("_")
             parsed_name[-1] = parsed_name[-1].split(".pkl")[0]
 
             if len(parsed_name) == 2:
-
                 sector = parsed_name[0].upper()
                 end_use = parsed_name[1].upper().replace("-", "_")
 
@@ -113,7 +108,6 @@ if __name__ == "__main__":
                 log_statement = f"{sector} {end_use} demand added to network"
 
             elif len(parsed_name) == 3:
-
                 sector = parsed_name[0].upper()
                 subsector = parsed_name[1].replace("-", "_")
                 end_use = parsed_name[2].upper()  # lpg | elec

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -49,7 +49,6 @@ from _helpers import (
     calculate_annuity,
     configure_logging,
     export_network_for_gis_mapping,
-    load_costs,
     update_p_nom_max,
     weighted_avg,
 )
@@ -86,7 +85,6 @@ def sanitize_carriers(n, config):
     --------
     Raises a warning if any carrier's "tech_colors" are not defined in the config dictionary.
     """
-
     for c in n.iterate_components():
         if "carrier" in c.df:
             add_missing_carriers(n, c.df.carrier)
@@ -134,7 +132,6 @@ def update_capital_costs(
     """
     Applies regional multipliers to capital cost data.
     """
-
     # map generators to states
     bus_state_mapper = n.buses.to_dict()["state"]
     gen = n.generators[n.generators.carrier == carrier].copy()
@@ -184,7 +181,6 @@ def apply_dynamic_pricing(
     vom: float = 0
         Additional flat $/MWh cost to add onto the fuel costs
     """
-
     assert geography in n.buses.columns
 
     gens = n.generators.copy()
@@ -599,7 +595,6 @@ def attach_egs(
     ) as ds_specs, xr.open_dataset(
         getattr(input_profiles, "profile_egs"),
     ) as ds_profile:
-
         bus2sub = (
             pd.read_csv(input_profiles.bus2sub, dtype=str)
             .drop("interconnect", axis=1)
@@ -828,7 +823,6 @@ def attach_breakthrough_renewable_plants(
     extendable_carriers,
     costs,
 ):
-
     add_missing_carriers(n, renewable_carriers)
 
     plants = pd.read_csv(fn_plants, dtype={"bus_id": str}, index_col=0).query(
@@ -887,7 +881,6 @@ def apply_pudl_fuel_costs(
     plants,
     costs,
 ):
-
     # Apply PuDL Fuel Costs for plants where listed
     pudl_fuel_costs = pd.read_csv(snakemake.input["pudl_fuel_costs"], index_col=0)
 
@@ -1045,7 +1038,7 @@ def main(snakemake):
     if params.conventional["dynamic_fuel_price"].get("enable", False):
         logger.info("Applying dynamic fuel pricing to conventional generators")
         if params.conventional["dynamic_fuel_price"]["wholesale"]:
-            assert params.eia_api, f"Must provide EIA API key for dynamic fuel pricing"
+            assert params.eia_api, "Must provide EIA API key for dynamic fuel pricing"
 
             dynamic_fuel_prices = {
                 "OCGT": {

--- a/workflow/scripts/add_extra_components.py
+++ b/workflow/scripts/add_extra_components.py
@@ -3,7 +3,6 @@ Adds extra extendable components to the clustered and simplified network.
 """
 
 import logging
-from typing import List
 
 import geopandas as gpd
 import numpy as np
@@ -281,7 +280,7 @@ def split_retirement_gens(
     n.generators["capital_cost"] = n.generators.apply(
         lambda row: (
             row["capital_cost"]
-            if not row.name in (retirement_gens.index)
+            if row.name not in (retirement_gens.index)
             else costs.at[row["carrier"], "opex_fixed_per_kw"] * 1e3
         ),
         axis=1,
@@ -289,7 +288,7 @@ def split_retirement_gens(
 
     # Rename retiring generators to include "existing" suffix
     n.generators.index = n.generators.apply(
-        lambda row: (row.name if not row.name in (retirement_gens.index) else row.name + " existing"),
+        lambda row: (row.name if row.name not in (retirement_gens.index) else row.name + " existing"),
         axis=1,
     )
 
@@ -305,9 +304,9 @@ def split_retirement_gens(
         n.generators["p_nom_min"],
     )
 
-    n.generators.loc[retirement_mask.values, "p_nom_extendable"] = (
-        economic  # if economic retirement is true enable extendable
-    )
+    n.generators.loc[
+        retirement_mask.values, "p_nom_extendable"
+    ] = economic  # if economic retirement is true enable extendable
 
     # Adding Expanding generators for the first investment period
     # There are generators that exist today and could expand

--- a/workflow/scripts/add_sectors.py
+++ b/workflow/scripts/add_sectors.py
@@ -50,7 +50,6 @@ def assign_bus_2_state(
 
     The shapefile must be the counties shapefile
     """
-
     buses = n.buses[["x", "y"]].copy()
     buses["geometry"] = buses.apply(lambda x: Point(x.x, x.y), axis=1)
     buses = gpd.GeoDataFrame(buses, crs="EPSG:4269")
@@ -85,7 +84,6 @@ def add_sector_foundation(
     only the bus is created and no energy supply will be added to the
     state level bus.
     """
-
     match carrier:
         case "gas":
             carrier_kwargs = {"color": "#d35050", "nice_name": "Natural Gas"}
@@ -151,7 +149,6 @@ def add_sector_foundation(
     )
 
     if add_supply:
-
         n.madd(
             "Store",
             names=points.index,
@@ -190,7 +187,6 @@ def convert_generators_2_links(
     bus0_suffix: str,
         suffix to attach link to
     """
-
     plants = n.generators[n.generators.carrier == carrier].copy()
 
     if plants.empty:
@@ -257,7 +253,6 @@ def split_loads_by_carrier(n: pypsa.Network):
     Note: This will break the flow of energy in the model! You must add a
     new link between the new bus and old bus if you want to retain the flow
     """
-
     for bus in n.buses.index.unique():
         df = n.loads[n.loads.bus == bus][["bus", "carrier"]]
 
@@ -284,7 +279,6 @@ def get_pwr_co2_intensity(carrier: str, costs: pd.DataFrame) -> float:
     Spereate function, as there is some odd logic to account for
     different names in translation to a sector study.
     """
-
     # the ccs case are a hack solution
 
     match carrier:
@@ -365,15 +359,15 @@ if __name__ == "__main__":
 
     for carrier in ("OCGT", "CCGT", "CCGT-95CCS", "CCGT-97CCS"):
         co2_intensity = get_pwr_co2_intensity(carrier, costs)
-        convert_generators_2_links(n, carrier, f" gas", co2_intensity)
+        convert_generators_2_links(n, carrier, " gas", co2_intensity)
 
     for carrier in ("coal", "coal-95CCS", "coal-99CCS"):
         co2_intensity = get_pwr_co2_intensity(carrier, costs)
-        convert_generators_2_links(n, carrier, f" coal", co2_intensity)
+        convert_generators_2_links(n, carrier, " coal", co2_intensity)
 
     for carrier in ["oil"]:
         co2_intensity = get_pwr_co2_intensity(carrier, costs)
-        convert_generators_2_links(n, carrier, f" oil", co2_intensity)
+        convert_generators_2_links(n, carrier, " oil", co2_intensity)
 
     ng_options = snakemake.params.sector["natural_gas"]
 
@@ -495,7 +489,6 @@ if __name__ == "__main__":
             )
 
     if snakemake.params.sector["service_sector"]["brownfield"]:
-
         res_stock_dir = snakemake.input.residential_stock
         com_stock_dir = snakemake.input.commercial_stock
 
@@ -504,7 +497,6 @@ if __name__ == "__main__":
         else:
             fuels = ["heating", "cooling"]
         for fuel in fuels:
-
             if fuel == "water_heating":
                 simple_storage = snakemake.params.sector["service_sector"]["water_heating"].get("simple_storage", False)
             else:
@@ -539,14 +531,12 @@ if __name__ == "__main__":
             )
 
     if snakemake.params.sector["industrial_sector"]["brownfield"]:
-
         mecs_file = snakemake.input.industrial_stock
         ratios = get_industrial_stock(mecs_file)
 
         fuels = ["heat"]
 
         for fuel in fuels:
-
             ratio = ratios.loc[fuel]
             add_industrial_brownfield(
                 n=n,

--- a/workflow/scripts/build_base_network.py
+++ b/workflow/scripts/build_base_network.py
@@ -1,16 +1,13 @@
 # BY PyPSA-USA Authors
 import logging
-from typing import Optional
 
-import constants as const
 import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pypsa
 from _helpers import configure_logging
 from build_shapes import load_na_shapes
-from geopandas.tools import sjoin
-from shapely.geometry import Point, Polygon
+from shapely.geometry import Polygon
 from sklearn.neighbors import BallTree
 
 
@@ -71,7 +68,6 @@ def add_buses_from_file(
 
 
 def add_branches_from_file(n: pypsa.Network, fn_branches: str) -> pypsa.Network:
-
     branches = pd.read_csv(
         fn_branches,
         dtype={"from_bus_id": str, "to_bus_id": str},
@@ -114,7 +110,6 @@ def assign_line_types(n: pypsa.Network):
 
 
 def add_dclines_from_file(n: pypsa.Network, fn_dclines: str) -> pypsa.Network:
-
     dclines = pd.read_csv(
         fn_dclines,
         dtype={"from_bus_id": str, "to_bus_id": str},
@@ -372,7 +367,7 @@ def build_offshore_transmission_configuration(n: pypsa.Network) -> pypsa.Network
     )
 
     # add offshore wind export cables
-    logger.info(f"Adding offshore wind export lines to the network.")
+    logger.info("Adding offshore wind export lines to the network.")
     n.madd(
         "Line",
         "OSW_export_" + osw_offsub_bus_ids,  # name line after offshore substation

--- a/workflow/scripts/build_bus_regions.py
+++ b/workflow/scripts/build_bus_regions.py
@@ -40,15 +40,16 @@ def voronoi_partition_pts(points, outline):
     Compute the polygons of a voronoi partition of `points` within the
     polygon `outline`. Taken from
     https://github.com/FRESNA/vresutils/blob/master/vresutils/graph.py
+
     Attributes
     ----------
     points : Nx2 - ndarray[dtype=float]
     outline : Polygon
+
     Returns
     -------
     polygons : N - ndarray[dtype=Polygon|MultiPolygon]
     """
-
     points = np.asarray(points)
 
     if len(points) == 1:

--- a/workflow/scripts/build_cost_data.py
+++ b/workflow/scripts/build_cost_data.py
@@ -3,7 +3,7 @@ Combines all time independent cost data sources into a standard format.
 """
 
 import logging
-from typing import Any, Optional
+from typing import Optional
 
 import constants as const
 import duckdb
@@ -78,7 +78,7 @@ def create_duckdb_instance(pudl_fn: str):
 
 
 def load_pudl_atb_data():
-    query = f"""
+    query = """
     WITH finance_cte AS (
         SELECT
         wacc_real,
@@ -105,7 +105,7 @@ def load_pudl_atb_data():
 
 
 def load_pudl_aeo_data():
-    query = f"""
+    query = """
     SELECT *
     FROM core_eiaaeo__yearly_projected_fuel_cost_in_electric_sector_by_type aeo
     WHERE aeo.report_year = 2023
@@ -169,7 +169,6 @@ def get_sector_costs(
         """
         Calcualtes capex based on annuity payments.
         """
-
         capex = df.copy().set_index(["technology", "parameter"])
         capex = capex.value.unstack().fillna(0)
 
@@ -507,9 +506,7 @@ if __name__ == "__main__":
     pivot_atb.loc[
         pivot_atb["pypsa-name"].str.contains("offshore"),
         "capex_grid_connection_per_kw_km",
-    ] = (
-        pivot_atb["capex_grid_connection_per_kw"] / 30
-    )
+    ] = pivot_atb["capex_grid_connection_per_kw"] / 30
 
     pivot_atb["annualized_connection_capex_per_mw_km"] = (
         calculate_annuity(

--- a/workflow/scripts/build_cutout.py
+++ b/workflow/scripts/build_cutout.py
@@ -90,7 +90,7 @@ import logging
 import atlite
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, get_snapshots
+from _helpers import configure_logging
 from pandas import Timestamp
 
 logger = logging.getLogger(__name__)

--- a/workflow/scripts/build_electricity_sector.py
+++ b/workflow/scripts/build_electricity_sector.py
@@ -18,9 +18,7 @@ def build_electricty(
     options: Optional[dict[str, Any]] = None,
 ) -> None:
     """Adds electricity sector infrastructre data"""
-
     if sector in ("res", "com", "srv"):
-
         split_urban_rural = options.get("split_urban_rural", False)
 
         if split_urban_rural:
@@ -51,7 +49,6 @@ def add_electricity_infrastructure(n: pypsa.Network, sector: str, suffix: Option
     For example, will build the link between "p480 0" and "p480 0 ind-
     elec"
     """
-
     elec = SecCarriers.ELECTRICITY.value
 
     if suffix:
@@ -89,7 +86,6 @@ def add_electricity_dr(
     """
     Adds stores to the network to use for demand response.
     """
-
     shift = dr_config.get("shift", 0)
     marginal_cost_storage = dr_config.get("marginal_cost", 0)
 
@@ -236,7 +232,6 @@ def _split_urban_rural_load(
     "p600 0 com-urban-elec" and "p600 0 com-rural-elec" at the same
     location as "p600 0").
     """
-
     assert sector in ("com", "res")
 
     fuel = SecCarriers.ELECTRICITY.value
@@ -244,7 +239,6 @@ def _split_urban_rural_load(
     load_names = n.loads[n.loads.carrier == f"{sector}-{fuel}"].index.to_list()
 
     for system in ("urban", "rural"):
-
         # add buses to connect the new loads to
         new_buses = pd.DataFrame(index=load_names)
         new_buses.index = new_buses.index.map(n.loads.bus)
@@ -302,7 +296,6 @@ def _format_total_load(
     """
     Formats load with 'total' prefix to match urban/rural split.
     """
-
     assert sector in ("com", "res", "srv")
 
     fuel = SecCarriers.ELECTRICITY.value

--- a/workflow/scripts/build_emission_tracking.py
+++ b/workflow/scripts/build_emission_tracking.py
@@ -20,7 +20,6 @@ def build_co2_tracking(
     """
     Main funtion to interface with.
     """
-
     states = n.buses.STATE.unique()
 
     sectors = ["pwr", "trn", "res", "com", "ind"]
@@ -46,7 +45,6 @@ def build_ch4_tracking(
 
     Natural gas network must already be constructed
     """
-
     states = [x for x in n.buses.STATE.dropna().unique() if x != np.nan]
 
     if not config:
@@ -77,7 +75,6 @@ def _build_co2_bus(n: pypsa.Network, states: list[str], sectors: list[str]):
     """
     Builds state level co2 bus per sector.
     """
-
     df = pd.DataFrame(itertools.product(states, sectors), columns=["state", "sector"])
     df.index = df.state + " " + df.sector
 
@@ -88,7 +85,6 @@ def _build_co2_store(n: pypsa.Network, states: list[str], sectors: list[str]):
     """
     Builds state level co2 stores per sector.
     """
-
     df = pd.DataFrame(itertools.product(states, sectors), columns=["state", "sector"])
     df.index = df.state + " " + df.sector
 
@@ -127,7 +123,6 @@ def _build_ch4_bus(n: pypsa.Network, states: list[str]):
     """
     Builds state level co2 bus per sector.
     """
-
     df = pd.DataFrame(states, columns=["state"])
     df.index = df.state
 
@@ -138,7 +133,6 @@ def _build_ch4_store(n: pypsa.Network, states: list[str]):
     """
     Builds state level co2 stores per sector.
     """
-
     df = pd.DataFrame(states, columns=["state"])
     df.index = df.state
 
@@ -164,7 +158,6 @@ def _build_ch4_links(n, states: list[str], gwp: float, leakage_rate: float):
     """
     Modifies existing gas production links.
     """
-
     # first extract out exising gas production links
 
     gas_production = [f"{x} gas production" for x in states]

--- a/workflow/scripts/build_fuel_prices.py
+++ b/workflow/scripts/build_fuel_prices.py
@@ -22,14 +22,10 @@ Build_fuel_prices.py is a script that prepares data for dynamic fuel prices to b
 """
 
 import logging
-import sys
 from pathlib import Path
-from typing import List
 
 import constants as const
-import duckdb
 import eia
-import numpy as np
 import pandas as pd
 from _helpers import configure_logging, get_snapshots, mock_snakemake
 from build_powerplants import (
@@ -50,7 +46,6 @@ def make_hourly(df: pd.DataFrame) -> pd.DataFrame:
     """
     Makes the index hourly.
     """
-
     start = df.index.min()
     end = (
         pd.to_datetime(start).to_period("Y").to_timestamp("Y").to_period("Y").to_timestamp("Y")
@@ -117,7 +112,6 @@ def get_caiso_ng_power_prices(
     filepath: str,
     **kwargs,
 ) -> pd.DataFrame:
-
     # pypsa-usa name: caiso name
     ba_mapper = {
         "CISO-PGAE": "CISO",

--- a/workflow/scripts/build_natural_gas.py
+++ b/workflow/scripts/build_natural_gas.py
@@ -163,7 +163,6 @@ class GasData(ABC):
         """
         Name of states must be in column called 'STATE'.
         """
-
         states_2_remove = self.states_2_remove
         if additional_removals:
             states_2_remove += additional_removals
@@ -247,7 +246,6 @@ class GasBuses(GasData):
         return df
 
     def build_infrastructure(self, n: Network) -> None:
-
         df = self.filter_on_sate(n, self.data)
 
         states = df.set_index("STATE")
@@ -339,7 +337,6 @@ class GasStorage(GasData):
         return df
 
     def build_infrastructure(self, n: pypsa.Network, **kwargs):
-
         df = self.filter_on_sate(n, self.data)
         df.index = df.STATE
         df["state_name"] = df.index.map(self.state_2_name)
@@ -455,7 +452,6 @@ class GasProcessing(GasData):
         return df
 
     def build_infrastructure(self, n: pypsa.Network, **kwargs):
-
         df = self.filter_on_sate(n, self.data)
         df = df.set_index("STATE")
         df["bus"] = df.index + " gas"
@@ -528,7 +524,6 @@ class GasProcessing(GasData):
 
 
 class _GasPipelineCapacity(GasData):
-
     def __init__(
         self,
         year: int,
@@ -561,7 +556,6 @@ class _GasPipelineCapacity(GasData):
         df: pd.DataFrame,
         in_spatial_scope: bool,
     ) -> pd.DataFrame:
-
         states_in_model = self.get_states_in_model(n)
 
         if ("STATE_TO" and "STATE_FROM") not in df.columns:
@@ -662,7 +656,6 @@ class _GasPipelineCapacity(GasData):
         capacity: pd.DataFrame,
         trade: pd.DataFrame,
     ) -> pd.DataFrame:
-
         df = pd.concat([capacity, trade])
         df = df.sort_values(by="CAPACITY_MW", ascending=False)
         df = df.drop_duplicates(
@@ -696,7 +689,6 @@ class _GasPipelineCapacity(GasData):
         """
         Adds interconnect labels to the pipelines.
         """
-
         df["STATE_TO"] = df.STATE_NAME_TO.map(self.name_2_state)
         df["STATE_FROM"] = df.STATE_NAME_FROM.map(self.name_2_state)
 
@@ -723,7 +715,6 @@ class InterconnectGasPipelineCapacity(_GasPipelineCapacity):
         super().__init__(year, interconnect, xlsx, api)
 
     def extract_pipelines(self, data: pd.DataFrame) -> pd.DataFrame:
-
         df = data.copy()
         # for some reason drop duplicates is not wokring here and I cant figure out why :(
         # df = df.drop_duplicates(subset=["STATE_TO", "STATE_FROM"], keep=False).copy()
@@ -746,7 +737,6 @@ class InterconnectGasPipelineCapacity(_GasPipelineCapacity):
         return df.reset_index(drop=True)
 
     def build_infrastructure(self, n: pypsa.Network) -> None:
-
         df = self.filter_on_sate(n, self.data, in_spatial_scope=True)
 
         if df.empty:
@@ -791,7 +781,6 @@ class TradeGasPipelineCapacity(_GasPipelineCapacity):
         super().__init__(year, interconnect, xlsx, api)
 
     def extract_pipelines(self, data: pd.DataFrame) -> pd.DataFrame:
-
         df = data.copy()
         if self.domestic:
             return self._get_domestic_pipeline_connections(df)
@@ -802,7 +791,6 @@ class TradeGasPipelineCapacity(_GasPipelineCapacity):
         """
         Gets all pipelines within the usa that connect to the interconnect.
         """
-
         # get rid of international connections
         df = df[~((df.INTERCONNECT_TO.isin(["canada", "mexico"])) | (df.INTERCONNECT_FROM.isin(["canada", "mexico"])))]
 
@@ -833,7 +821,6 @@ class TradeGasPipelineCapacity(_GasPipelineCapacity):
         interpolation_method can be one of:
         - linear, zero
         """
-
         assert direction in ("imports", "exports")
 
         # fuel costs/profits at a national level
@@ -940,7 +927,6 @@ class TradeGasPipelineCapacity(_GasPipelineCapacity):
         """
         Gets time varrying import/export costs.
         """
-
         df = connections.copy()
 
         states_in_model = self.get_states_in_model(n)
@@ -964,7 +950,6 @@ class TradeGasPipelineCapacity(_GasPipelineCapacity):
 
         Country is always in model spatial scope.
         """
-
         df = template.copy()
         states_in_model = self.get_states_in_model(n)
 
@@ -1013,7 +998,6 @@ class TradeGasPipelineCapacity(_GasPipelineCapacity):
         imports) If bus0 is a state gas bus, energy will flow out of the
         model (ie. exports)
         """
-
         df = template.copy()
 
         df["store"] = df.bus0.map(
@@ -1041,7 +1025,6 @@ class TradeGasPipelineCapacity(_GasPipelineCapacity):
             - "WA BC gas trade"
             - "BC WA gas trade"
         """
-
         df = self.filter_on_sate(n, self.data, in_spatial_scope=False)
 
         df = self._add_zero_capacity_connections(df)
@@ -1165,7 +1148,6 @@ class PipelineLinepack(GasData):
         n: pypsa.Network,
         df: pd.DataFrame,
     ) -> pd.DataFrame:
-
         states_in_model = n.buses[
             ~n.buses.carrier.isin(
                 ["gas storage", "gas trade", "gas pipeline"],
@@ -1230,7 +1212,6 @@ class PipelineLinepack(GasData):
         return self.filter_on_interconnect(final)
 
     def build_infrastructure(self, n: pypsa.Network, **kwargs) -> None:
-
         df = self.filter_on_sate(n, self.data)
         df = df.set_index("STATE")
 
@@ -1269,7 +1250,6 @@ def _remove_marginal_costs(n: pypsa.Network):
     """
     Removes marginal costs of CCGT and OCGT plants.
     """
-
     links = n.links[n.links.carrier.str.contains("CCGT") | n.links.carrier.str.contains("OCGT")].index
 
     n.links.loc[links, "marginal_cost"] = 0
@@ -1291,7 +1271,6 @@ def build_natural_gas(
     options: Optional[dict[str, Any]] = None,
     **kwargs,
 ) -> None:
-
     if not options:
         options = {}
 

--- a/workflow/scripts/build_population_layouts.py
+++ b/workflow/scripts/build_population_layouts.py
@@ -12,7 +12,6 @@ import atlite
 import constants
 import geopandas as gpd
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 import xarray as xr
 from _helpers import configure_logging, mock_snakemake
@@ -83,7 +82,6 @@ def plot_county_data(
     Adapted from
     https://www.relataly.com/visualize-covid-19-data-on-a-geographic-heat-maps/291/
     """
-
     # for legend range
     vmin = gdf[col].min()
     vmax = gdf[col].max()
@@ -117,7 +115,6 @@ def plot_grid_data(da: xr.DataArray, title: str = None, save: str = None):
     """
     Plots gridded population layout.
     """
-
     fig, ax = plt.subplots(figsize=(5, 4))
     da.plot(ax=ax, cbar_kwargs={"label": "population"})
     ax.set_xlabel("longitude")
@@ -206,7 +203,6 @@ if __name__ == "__main__":
 
     # plot data
     if save_path:
-
         plotting_data = counties.copy()
         plotting_data["density_person_per_km2"] = plotting_data.population / counties.ALAND * 1000000
         columns = {

--- a/workflow/scripts/build_powerplants.py
+++ b/workflow/scripts/build_powerplants.py
@@ -774,8 +774,8 @@ def set_parameters(plants: pd.DataFrame):
 
     set_derates(plants)
 
-    plants[f"heat_rate_source"] = plants[f"heat_rate_source"].fillna("NA")
-    plants[f"fuel_cost_source"] = plants[f"fuel_cost_source"].fillna("NA")
+    plants["heat_rate_source"] = plants["heat_rate_source"].fillna("NA")
+    plants["fuel_cost_source"] = plants["fuel_cost_source"].fillna("NA")
 
     # Check for missing heat rate data
     if plants["heat_rate"].isna().sum() > 0:

--- a/workflow/scripts/build_renewable_profiles.py
+++ b/workflow/scripts/build_renewable_profiles.py
@@ -163,7 +163,6 @@ import atlite
 import geopandas as gpd
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 import xarray as xr
 from _helpers import configure_logging, get_snapshots
 from dask.distributed import Client
@@ -276,7 +275,7 @@ if __name__ == "__main__":
 
     if params.get("boem_screen", 0):
         excluder.add_raster(
-            snakemake.input[f"boem_osw"],
+            snakemake.input["boem_osw"],
             invert=True,
             nodata=0,
             allow_no_overlap=True,

--- a/workflow/scripts/build_sector_costs.py
+++ b/workflow/scripts/build_sector_costs.py
@@ -9,7 +9,6 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 import pandas as pd
-import xarray as xr
 from constants import TBTU_2_MWH, MMBTU_MWHthemal
 
 # Vehicle life assumptions for getting $/VMT capital cost
@@ -496,7 +495,6 @@ class EfsIceTransportationData:
 
 
 class EfsBuildingData(EfsSectorData):
-
     mmbtu_2_mwh = MMBTU_MWHthemal
 
     # Assumptions from https://atb.nrel.gov/transportation/2022/definitions

--- a/workflow/scripts/build_shapes.py
+++ b/workflow/scripts/build_shapes.py
@@ -41,12 +41,9 @@ The `build_shapes` rule builds the GIS shape files for the balancing authorities
 
 
 import logging
-from typing import List
 
-import cartopy.crs as ccrs
 import cartopy.io.shapereader as shpreader
 import geopandas as gpd
-import matplotlib.pyplot as plt
 import pandas as pd
 from _helpers import configure_logging, mock_snakemake
 from constants import *
@@ -61,11 +58,13 @@ def filter_small_polygons_gpd(
     Filters out polygons within each MultiPolygon in a GeoSeries that are
     smaller than a specified area.
 
-    Parameters:
+    Parameters
+    ----------
     geo_series (gpd.GeoSeries): A GeoSeries containing MultiPolygon geometries.
     min_area (float): The minimum area threshold.
 
-    Returns:
+    Returns
+    -------
     gpd.GeoSeries: A GeoSeries with MultiPolygons filtered based on the area criterion.
     """
     # Explode the MultiPolygons into individual Polygons
@@ -127,7 +126,6 @@ def filter_shapes(
     """
     Filters breakthrough energy zone data by interconnect region.
     """
-
     if interconnect not in ("western", "texas", "eastern", "usa"):
         logger.warning(f"Interconnector of {interconnect} is not valid")
 

--- a/workflow/scripts/cluster_network.py
+++ b/workflow/scripts/cluster_network.py
@@ -201,9 +201,7 @@ def busmap_for_n_clusters(
 
                 neighbor_bus = n.lines.query(
                     "bus0 == @disconnected_bus or bus1 == @disconnected_bus",
-                ).iloc[
-                    0
-                ][["bus0", "bus1"]]
+                ).iloc[0][["bus0", "bus1"]]
                 new_country = list(
                     set(n.buses.loc[neighbor_bus].country) - {country},
                 )[0]

--- a/workflow/scripts/constants.py
+++ b/workflow/scripts/constants.py
@@ -4,8 +4,6 @@ Module for holding global constant values.
 
 from enum import Enum
 
-import pandas as pd
-
 ###########################################
 # Constants for GIS Coordinate Reference Systems
 ###########################################

--- a/workflow/scripts/eia.py
+++ b/workflow/scripts/eia.py
@@ -9,7 +9,8 @@ Public Classes include:
 - Storage(fuel, storage, year, api)
 - Emissions(sector, year, api, fuel)
 
-Examples:
+Examples
+--------
 >>> costs = FuelCosts("gas", "power", 2020, "xxxxxxxxxxxxxxxx")
 >>> costs.get_data()
 
@@ -142,7 +143,6 @@ class EiaData(ABC):
 
 # concrete creator
 class FuelCosts(EiaData):
-
     def __init__(
         self,
         fuel: str,
@@ -192,7 +192,6 @@ class FuelCosts(EiaData):
 
 # concrete creator
 class Trade(EiaData):
-
     def __init__(
         self,
         fuel: str,
@@ -225,7 +224,6 @@ class Trade(EiaData):
 
 # concrete creator
 class Production(EiaData):
-
     def __init__(self, fuel: str, production: str, year: int, api: str) -> None:
         self.fuel = fuel  # (gas)
         self.production = production  # (marketed|gross)
@@ -391,7 +389,6 @@ class TransportationFuelUse(EiaData):
 
 # concrete creator
 class Storage(EiaData):
-
     def __init__(self, fuel: str, storage: str, year: int, api: str) -> None:
         self.fuel = fuel
         self.storage = storage  # (base|working|total|withdraw)
@@ -411,7 +408,6 @@ class Storage(EiaData):
 
 # concrete creator
 class Emissions(EiaData):
-
     def __init__(self, sector: str, year: int, api: str, fuel: str = None) -> None:
         self.sector = sector  # (power|residential|commercial|industry|transport|total)
         self.year = year  # 1970 - 2021
@@ -445,7 +441,6 @@ class Seds(EiaData):
 
 
 class ElectricPowerData(EiaData):
-
     def __init__(self, sector: str, year: int, api_key: str) -> None:
         self.sector = sector
         self.year = year
@@ -508,7 +503,6 @@ class DataExtractor(ABC):
 
         url in the form of "https://api.eia.gov/v2/" followed by api key and facets
         """
-
         # sometimes running into HTTPSConnectionPool error. adding in retries helped
         session = requests.Session()
         retries = Retry(
@@ -570,7 +564,6 @@ class DataExtractor(ABC):
 
 # concrete product
 class GasCosts(DataExtractor):
-
     industry_codes = {
         "power": "PEU",
         "residential": "PRS",
@@ -599,7 +592,6 @@ class GasCosts(DataExtractor):
         """
         Formats natural gas cost data.
         """
-
         # format dates
         df["period"] = self._format_period(df.period)
         df = df.set_index("period").copy()
@@ -637,7 +629,6 @@ class GasCosts(DataExtractor):
 
 # concrete product
 class CoalCosts(DataExtractor):
-
     industry_codes = {
         "power": "PEU",
     }
@@ -658,7 +649,6 @@ class CoalCosts(DataExtractor):
         return f"{API_BASE}{base_url}?api_key={self.api_key}&{facets}"
 
     def format_data(self, df: pd.DataFrame) -> pd.DataFrame:
-
         df = df[
             (df.coalRankId.isin(["TOT"]))
             & ~(df.price == "w")
@@ -768,7 +758,7 @@ class LpgCosts(DataExtractor):
 
     def __init__(self, grade: str, year: int, api_key: str) -> None:
         self.grade = grade
-        if not grade in self.grade_codes:
+        if grade not in self.grade_codes:
             raise InputException(
                 propery="Lpg Costs",
                 valid_options=list(self.grade_codes),
@@ -782,7 +772,6 @@ class LpgCosts(DataExtractor):
         return f"{API_BASE}{base_url}?api_key={self.api_key}&{facets}"
 
     def format_data(self, df: pd.DataFrame) -> pd.DataFrame:
-
         data = df[["period", "area-name", "series-description", "value", "units"]].copy()
 
         data["state"] = data["area-name"].map(self.padd_2_state)
@@ -804,7 +793,7 @@ class HeatingFuelCosts(DataExtractor):
 
     def __init__(self, heating_fuel: str, year: int, api_key: str) -> None:
         self.heating_fuel = heating_fuel
-        if not heating_fuel in self.heating_fuel_codes:
+        if heating_fuel not in self.heating_fuel_codes:
             raise InputException(
                 propery="Heating Fuel Costs",
                 valid_options=list(self.heating_fuel_codes),
@@ -818,7 +807,6 @@ class HeatingFuelCosts(DataExtractor):
         return f"{API_BASE}{base_url}?api_key={self.api_key}&{facets}"
 
     def format_data(self, df: pd.DataFrame) -> pd.DataFrame:
-
         data = df[
             (
                 df["product-name"].str.startswith(
@@ -1467,12 +1455,11 @@ class InternationalGasTrade(DataExtractor):
         super().__init__(year, api_key)
 
     def build_url(self) -> str:
-        base_url = f"natural-gas/move/ist/data/"
+        base_url = "natural-gas/move/ist/data/"
         facets = f"frequency=annual&data[0]=value&facets[process][]={self.direction_codes[self.direction]}&start={self.year-1}&end={self.year}&sort[0][column]=period&sort[0][direction]=desc&offset=0&length=5000"
         return f"{API_BASE}{base_url}?api_key={self.api_key}&{facets}"
 
     def format_data(self, df: pd.DataFrame) -> pd.DataFrame:
-
         df["period"] = pd.to_datetime(df.period).map(lambda x: x.year)
 
         # extract only canada and mexico trade
@@ -1534,12 +1521,11 @@ class DomesticGasTrade(DataExtractor):
         super().__init__(year, api_key)
 
     def build_url(self) -> str:
-        base_url = f"natural-gas/move/ist/data/"
+        base_url = "natural-gas/move/ist/data/"
         facets = f"frequency=annual&data[0]=value&facets[process][]={self.direction_codes[self.direction]}&start={self.year-1}&end={self.year}&sort[0][column]=period&sort[0][direction]=desc&offset=0&length=5000"
         return f"{API_BASE}{base_url}?api_key={self.api_key}&{facets}"
 
     def format_data(self, df: pd.DataFrame) -> pd.DataFrame:
-
         df["period"] = pd.to_datetime(df.period).map(lambda x: x.year)
 
         # drop Federal Offshore--Gulf of Mexico Natural Gas Interstate Receipts
@@ -1605,7 +1591,6 @@ class GasStorage(DataExtractor):
         return f"{API_BASE}{base_url}?api_key={self.api_key}&{facets}"
 
     def format_data(self, df: pd.DataFrame) -> pd.DataFrame:
-
         df = df[~(df["area-name"] == "NA")].copy()
         df["period"] = self._format_period(df.period)
         df["state"] = df["series-description"].map(self.extract_state).map(self.map_state_names)
@@ -1659,7 +1644,6 @@ class GasProduction(DataExtractor):
         return f"{API_BASE}{base_url}?api_key={self.api_key}&{facets}"
 
     def format_data(self, df: pd.DataFrame) -> pd.DataFrame:
-
         df = df[~(df["area-name"] == "NA")].copy()
         df["period"] = self._format_period(df.period)
         df["state"] = df["series-description"].map(self.extract_state).map(self.map_state_names)
@@ -1738,7 +1722,6 @@ class StateEmissions(DataExtractor):
         return f"{API_BASE}{base_url}?api_key={self.api_key}&{facets}"
 
     def format_data(self, df: pd.DataFrame) -> pd.DataFrame:
-
         df = df[~(df["state-name"] == "NA")].copy()
         df = df.rename(
             columns={
@@ -1793,7 +1776,6 @@ class SedsConsumption(DataExtractor):
         return f"{API_BASE}{base_url}?api_key={self.api_key}&{facets}"
 
     def format_data(self, df: pd.DataFrame) -> pd.DataFrame:
-
         df = df.rename(
             columns={
                 "unit": "units",

--- a/workflow/scripts/eulp.py
+++ b/workflow/scripts/eulp.py
@@ -6,7 +6,6 @@ Holds data processing class for NREL End Use Load Profiles.
 See `retrieve_eulp` rule for the data extraction
 """
 
-import logging
 from typing import Optional
 
 import pandas as pd
@@ -171,7 +170,7 @@ class Eulp:
             )
         else:
             raise TypeError(
-                f"missing 1 required positional argument: 'filepath' or 'df'",
+                "missing 1 required positional argument: 'filepath' or 'df'",
             )
 
     def __add__(self, other):
@@ -228,7 +227,6 @@ class Eulp:
         return resampled.sort_index()
 
     def _aggregate_data(self, df: pd.DataFrame) -> pd.DataFrame:
-
         def aggregate_sector(df: pd.DataFrame, columns: list[str]) -> pd.Series:
             sector_columns = [x for x in columns if x in df.columns.to_list()]
             return df[sector_columns].sum(axis=1)
@@ -259,7 +257,6 @@ class Eulp:
         ],
         resample: Optional[str] = None,
     ):
-
         if isinstance(sectors, str):
             sectors = [sectors]
 
@@ -301,7 +298,7 @@ class EulpTotals:
             assert (self.data.columns == ["electricity", "gas", "oil", "propane"]).all()
         else:
             raise TypeError(
-                f"missing 1 required positional argument: 'filepath' or 'df'",
+                "missing 1 required positional argument: 'filepath' or 'df'",
             )
 
     def __add__(self, other):
@@ -354,7 +351,6 @@ class EulpTotals:
         return resampled.sort_index()
 
     def _aggregate_data(self, df: pd.DataFrame) -> pd.DataFrame:
-
         def aggregate_sector(df: pd.DataFrame, columns: list[str]) -> pd.Series:
             sector_columns = [x for x in columns if x in df.columns.to_list()]
             return df[sector_columns].sum(axis=1)
@@ -377,7 +373,6 @@ class EulpTotals:
         self,
         sectors: Optional[list[str] | str] = ["electricity", "gas", "oil", "propane"],
     ):
-
         if isinstance(sectors, str):
             sectors = [sectors]
 

--- a/workflow/scripts/generate_stochastic_samples.py
+++ b/workflow/scripts/generate_stochastic_samples.py
@@ -18,7 +18,7 @@ import xarray as xr
 
 def import_profiles_from_folder(PATH_FILES):
     filelist = []
-    for file in glob.glob(os.path.join(PATH_FILES, f"*.csv")):
+    for file in glob.glob(os.path.join(PATH_FILES, "*.csv")):
         filelist.append(os.path.join(file))
     load_base = pd.read_csv([s for s in filelist if "loads" in s][0], index_col=0)
     solar_base = pd.read_csv([s for s in filelist if "solar" in s][0], index_col=0)
@@ -34,7 +34,8 @@ def import_profiles_from_network(PATH_NETWORK, num_clusters):
         network_path (str): Path to the pypsa network.
         num_clusters (int): Number of clusters to be used in the network.
 
-    Returns:
+    Returns
+    -------
         pandas.DataFrame: Base load profile.
         pandas.DataFrame: Base solar profile.
         pandas.DataFrame: Base wind profile.
@@ -76,7 +77,8 @@ def resample_and_group(base_data, area_mapping):
         base_data (pandas.DataFrame): Input data to be resampled.
         area_mapping (dict): Dictionary mapping column names to area ids.
 
-    Returns:
+    Returns
+    -------
         pandas.DataFrame: Resampled data, grouped by day of year and area id.
     """
     base_area = base_data.groupby(
@@ -97,7 +99,8 @@ def create_allocation(base, mapping):
         base (pandas.DataFrame): Input data to be resampled.
         mapping (pandas.DataFrame): Dictionary mapping column names to area ids.
 
-    Returns:
+    Returns
+    -------
         pandas.DataFrame: Hourly allocation of generation based on the mean of the base data.
     """
     base_ = base.copy().reset_index(drop=True)
@@ -120,7 +123,8 @@ def define_solar_hours(solar_profile, timestamps):
         solar_profile (pandas.DataFrame): Solar generation profile.
         timestamps (pandas.DataFrame): Timestamps for the solar generation profile.
 
-    Returns:
+    Returns
+    -------
         pandas.DataFrame: First and last hour of the day for solar generation.
     """
     first_hour, last_hour, yesterday_last_hour = np.zeros((3, len(solar_profile)))
@@ -150,7 +154,8 @@ def assign_stochastic_mu(df_params, timestamp_reference, column_name="profile_ty
         timestamp_reference (pandas.DataFrame): Dataframe containing the timestamp reference.
         column_name (str): Column name to be used for the merge.
 
-    Returns:
+    Returns
+    -------
         pandas.DataFrame: Dataframe containing the stochastic mu for each hour of the year.
     """
     df_mu_hourly = pd.merge(
@@ -177,7 +182,8 @@ def sampling_warmup(df, thresholds, rng, min_steps=50):
         rng (numpy.random.Generator): Random number generator.
         min_steps (int): Minimum number of steps to be performed.
 
-    Returns:
+    Returns
+    -------
         pandas.DataFrame: Dataframe containing the first sample of the ratio and epsilon.
     """
     winter_params = df.query("season == 1")
@@ -227,7 +233,6 @@ def resample_ratio(
         if np.any(
             np.logical_or(resampled_ratio > thresholds, resampled_ratio < 0),
         ):  # if any values are still out of bounds
-
             in_bounds_mask = np.logical_and(
                 mask_to_resample,
                 np.logical_and(resampled_ratio < thresholds, resampled_ratio > 0),
@@ -436,7 +441,6 @@ for sample_num in range(0, num_samples):
     )
 
     for i in range(1, n_hours):
-
         season_df = parameters_concat[parameters_concat.season == timestamp_reference.iloc[i].season_num]
         p_eps = rng_eps(season_df, rng)
         ratio_samples.iloc[i, :] = (

--- a/workflow/scripts/plot_natural_gas.py
+++ b/workflow/scripts/plot_natural_gas.py
@@ -1,6 +1,5 @@
 import logging
-import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 from typing import Any, Optional
@@ -76,7 +75,6 @@ def _sum_state_trade_data(
     """
     Sums state data together.
     """
-
     import_data = {}
     export_data = {}
 
@@ -111,7 +109,6 @@ def plot_gas(
     """
     General gas plotting function.
     """
-
     df = data.copy()
 
     if df.empty:
@@ -151,7 +148,6 @@ def plot_gas_trade(
     """
     General gas trade plotting function.
     """
-
     # periods will be the same for imports or exports
     periods = data["imports"].index.get_level_values("period").unique()
 
@@ -160,7 +156,6 @@ def plot_gas_trade(
     fig, axs = plt.subplots(n_rows, 2, sharey=True, figsize=(FIG_WIDTH, FIG_HEIGHT * n_rows))
 
     for i, period in enumerate(periods):
-
         # plot imports
 
         imports = data["imports"].copy()
@@ -285,7 +280,6 @@ PLOTTING_META = [
 ]
 
 if __name__ == "__main__":
-
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
@@ -329,7 +323,6 @@ if __name__ == "__main__":
         expected_figures[result] = state_paths
 
     for meta in plotting_metadata:
-
         if meta.name not in expected_figures:
             logger.warning(f"Not expecting {meta.name} natural gas chart")
             continue
@@ -337,7 +330,6 @@ if __name__ == "__main__":
         data = meta.getter(n)
 
         for state in states:
-
             if state == "system":
                 if _is_trade_data(data):
                     state_data = _sum_state_trade_data(data)
@@ -390,7 +382,6 @@ if __name__ == "__main__":
             months = {month.value: _get_month_name(month) for month in Month}
 
             for month_i, month_name in months.items():
-
                 if isinstance(state_data, pd.DataFrame):
                     if not state_data.empty:
                         state_data_month = state_data[state_data.index.get_level_values("timestep").month == month_i]

--- a/workflow/scripts/plot_network_maps.py
+++ b/workflow/scripts/plot_network_maps.py
@@ -160,7 +160,6 @@ def plot_emissions_map(
     save: str,
     **wildcards,
 ) -> None:
-
     # get data
 
     emissions = (

--- a/workflow/scripts/plot_sankey_carbon.py
+++ b/workflow/scripts/plot_sankey_carbon.py
@@ -81,7 +81,6 @@ NAME_MAPPER = {
 
 
 def get_pwr_flows(n: pypsa.Network, investment_period: int, state: str) -> pd.DataFrame:
-
     if state:
         links_in_state = _get_links_in_state(n, state)
     else:
@@ -124,7 +123,6 @@ def get_sector_flows(
     investment_period: int,
     state: str,
 ) -> pd.DataFrame:
-
     weights = n.snapshot_weightings.objective
 
     if state:
@@ -181,7 +179,6 @@ def format_sankey_data(
     name_mapper: dict[str, str],
     sankey_codes: dict[str, int],
 ) -> pd.DataFrame:
-
     def map_sankey_name(name: str):
         try:
             return name_mapper[name]
@@ -222,7 +219,6 @@ def format_sankey_data(
 ###
 
 if __name__ == "__main__":
-
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
@@ -261,7 +257,6 @@ if __name__ == "__main__":
     # plot state level
 
     for state in states:
-
         df = get_sankey_dataframe(
             n=n,
             investment_period=investment_period,

--- a/workflow/scripts/plot_sankey_energy.py
+++ b/workflow/scripts/plot_sankey_energy.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Optional
 
 import pandas as pd
-import plotly
 import plotly.graph_objects as go
 import pypsa
 from _helpers import configure_logging, mock_snakemake
@@ -104,7 +103,6 @@ def _get_consumption_generators(
     period: int,
     state: Optional[str] = None,
 ) -> pd.DataFrame:
-
     if state:
         generators = _get_gens_in_state(n, state)
     else:
@@ -125,7 +123,6 @@ def _get_rejected_generators(
     period: int,
     state: Optional[str] = None,
 ) -> pd.DataFrame:
-
     if state:
         generators = _get_gens_in_state(n, state)
     else:
@@ -166,7 +163,6 @@ def _get_rejected_links(
     period: int,
     state: Optional[str] = None,
 ) -> pd.DataFrame:
-
     if state:
         links = _get_links_in_state(n, state)
     else:
@@ -237,7 +233,6 @@ def _get_sector_consumption(
     period: int,
     state: Optional[str] = None,
 ) -> float:
-
     if fuel == "elec":
         fuel = "AC"
 
@@ -264,7 +259,6 @@ def _get_service_supply(
     period: int,
     state: Optional[str] = None,
 ) -> float:
-
     if state:
         links_in_state = _get_links_in_state(n, state)
     else:
@@ -294,7 +288,6 @@ def _get_service_rejected(
     period: int,
     state: Optional[str] = None,
 ) -> float:
-
     if state:
         links_in_state = _get_links_in_state(n, state)
     else:
@@ -321,7 +314,6 @@ def _get_industry_supply(
     period: int,
     state: Optional[str] = None,
 ) -> float:
-
     if state:
         links_in_state = _get_links_in_state(n, state)
     else:
@@ -342,7 +334,6 @@ def _get_industry_rejected(
     period: int,
     state: Optional[str] = None,
 ) -> float:
-
     if state:
         links_in_state = _get_links_in_state(n, state)
     else:
@@ -369,7 +360,6 @@ def _get_transport_supply(
     period: int,
     state: Optional[str] = None,
 ) -> float:
-
     if state:
         links_in_state = _get_links_in_state(n, state)
     else:
@@ -404,7 +394,6 @@ def _get_transport_rejected(
     period: int,
     state: Optional[str] = None,
 ) -> float:
-
     if state:
         links_in_state = _get_links_in_state(n, state)
     else:
@@ -441,7 +430,6 @@ def get_energy_flow_res(
     period: int,
     state: Optional[str] = None,
 ) -> pd.DataFrame:
-
     elec_consumption = _get_sector_consumption(n, "res", "elec", period, state)
     lpg_consumption = _get_sector_consumption(n, "res", "oil", period, state)
     gas_consumption = _get_sector_consumption(n, "res", "gas", period, state)
@@ -468,7 +456,6 @@ def get_energy_flow_com(
     period: int,
     state: Optional[str] = None,
 ) -> pd.DataFrame:
-
     elec_consumption = _get_sector_consumption(n, "com", "elec", period, state)
     lpg_consumption = _get_sector_consumption(n, "com", "oil", period, state)
     gas_consumption = _get_sector_consumption(n, "com", "gas", period, state)
@@ -495,7 +482,6 @@ def get_energy_flow_ind(
     period: int,
     state: Optional[str] = None,
 ) -> pd.DataFrame:
-
     elec_consumption = _get_sector_consumption(n, "ind", "elec", period, state)
     coal_consumption = _get_sector_consumption(n, "ind", "coal", period, state)
     gas_consumption = _get_sector_consumption(n, "ind", "gas", period, state)
@@ -522,7 +508,6 @@ def get_energy_flow_trn(
     period: int,
     state: Optional[str] = None,
 ) -> pd.DataFrame:
-
     elec_consumption = _get_sector_consumption(n, "trn", "elec", period, state)
     oil_consumption = _get_sector_consumption(n, "trn", "oil", period, state)
 
@@ -571,7 +556,6 @@ def format_sankey_data(
     name_mapper: dict[str, str],
     sankey_codes: dict[str, int],
 ) -> pd.DataFrame:
-
     def map_sankey_name(name: str):
         try:
             return name_mapper[name]
@@ -612,7 +596,6 @@ def format_sankey_data(
 ###
 
 if __name__ == "__main__":
-
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
@@ -653,7 +636,6 @@ if __name__ == "__main__":
     # plot state level
 
     for state in states:
-
         df = get_sankey_dataframe(
             n=n,
             pwr_carriers=power_carriers,

--- a/workflow/scripts/plot_statistics.py
+++ b/workflow/scripts/plot_statistics.py
@@ -283,11 +283,13 @@ def get_statistics(n, column_name):
     """
     Prepare the statistics data for plotting by extracting and grouping by region and carrier.
 
-    Parameters:
+    Parameters
+    ----------
     - n: pypsa.Network
     - column_name: str, the name of the column to extract from statistics (e.g., 'Optimal Capacity', 'Supply')
 
-    Returns:
+    Returns
+    -------
     - pd.DataFrame: Prepared and grouped data
     """
     groupers = n.statistics.groupers
@@ -324,7 +326,8 @@ def plot_bar(data, n, save, title, ylabel, is_capacity=False):
     """
     Plot the data in a bar chart with subplots by region and carrier.
 
-    Parameters:
+    Parameters
+    ----------
     - data: pd.DataFrame, data to plot
     - n: pypsa.Network
     - save: str, file path to save the plot
@@ -697,7 +700,6 @@ def plot_generator_data_panel(
     save: str,
     **wildcards,
 ):
-
     df_capex_expand = n.generators.loc[
         n.generators.p_nom_extendable & ~n.generators.index.str.contains("existing"),
         :,
@@ -847,7 +849,6 @@ def plot_fuel_costs(
     save: str,
     **wildcards,
 ) -> None:
-
     fuel_costs = get_fuel_costs(n)
 
     fuels = set(fuel_costs.index.get_level_values("carrier"))
@@ -867,9 +868,9 @@ def plot_fuel_costs(
         legend=True,
         palette=color_palette,
     )
-    axs[0].set_title("Daily Average Fuel Costs [$/MWh]"),
-    axs[0].set_xlabel(""),
-    axs[0].set_ylabel("$/MWh"),
+    (axs[0].set_title("Daily Average Fuel Costs [$/MWh]"),)
+    (axs[0].set_xlabel(""),)
+    (axs[0].set_ylabel("$/MWh"),)
 
     # plot bus fuel prices for each fuel
     for i, fuel in enumerate(fuels):
@@ -882,9 +883,9 @@ def plot_fuel_costs(
             dashes=False,
             ax=axs[i + 1],
         )
-        axs[i + 1].set_title(f"Daily Average {nice_name} Fuel Costs per Bus [$/MWh]"),
-        axs[i + 1].set_xlabel(""),
-        axs[i + 1].set_ylabel("$/MWh"),
+        (axs[i + 1].set_title(f"Daily Average {nice_name} Fuel Costs per Bus [$/MWh]"),)
+        (axs[i + 1].set_xlabel(""),)
+        (axs[i + 1].set_ylabel("$/MWh"),)
 
     fig.savefig(save)
     plt.close()

--- a/workflow/scripts/plot_statistics_sector.py
+++ b/workflow/scripts/plot_statistics_sector.py
@@ -3,11 +3,12 @@ Plots Sector Coupling Statistics.
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from math import ceil
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -15,7 +16,7 @@ import pypsa
 import seaborn as sns
 from _helpers import configure_logging, mock_snakemake
 from add_electricity import sanitize_carriers
-from constants import STATE_2_CODE, Month
+from constants import Month
 from constants_sector import (
     AirTransport,
     AirTransportUnits,
@@ -36,11 +37,8 @@ from summary_sector import (  # get_load_name_per_sector,
     get_end_use_load_timeseries_carrier,
     get_hp_cop,
     get_load_factor_timeseries,
-    get_load_per_sector_per_fuel,
-    get_sector_production_timeseries,
     get_sector_production_timeseries_by_carrier,
     get_storage_level_timeseries_carrier,
-    get_transport_consumption_by_mode,
 )
 
 logger = logging.getLogger(__name__)
@@ -79,7 +77,6 @@ def is_urban_rural_split(n: pypsa.Network) -> bool:
     """
     Checks for urban/rural split based on com/res load names.
     """
-
     com_res_load = n.loads[(n.loads.index.str.contains("res-")) | (n.loads.index.str.contains("com-"))].index.to_list()
 
     rural_urban_loads = ["res-urban-", "res-rural-", "com-urban-", "com-rural-"]
@@ -91,7 +88,6 @@ def is_urban_rural_split(n: pypsa.Network) -> bool:
 
 
 def get_plotting_colors(n: pypsa.Network, nice_name: bool) -> dict[str, str]:
-
     if nice_name:
         return n.carriers.set_index("nice_name")["color"].to_dict()
     else:
@@ -114,7 +110,6 @@ def plot_hp_cop(n: pypsa.Network, state: Optional[str] = None, **kwargs) -> tupl
     """
     Plots gshp and ashp cops.
     """
-
     investment_period = n.investment_periods[0]
 
     cops = get_hp_cop(n, state).loc[investment_period]
@@ -127,7 +122,6 @@ def plot_hp_cop(n: pypsa.Network, state: Optional[str] = None, **kwargs) -> tupl
     )
 
     for i, hp in enumerate(["ashp", "gshp"]):
-
         df = cops[[x for x in cops if x.endswith(hp)]]
         avg = df.mean(axis=1)
 
@@ -138,7 +132,6 @@ def plot_hp_cop(n: pypsa.Network, state: Optional[str] = None, **kwargs) -> tupl
         palette = sns.color_palette(["lightgray"], df.shape[1])
 
         try:
-
             sns.lineplot(
                 df,
                 color="lightgray",
@@ -172,7 +165,6 @@ def plot_sector_production_timeseries(
     """
     Plots timeseries production as area chart.
     """
-
     y_label = kwargs.get("ylabel", "MWh")
 
     assert sector in ("res", "com", "ind", "pwr")
@@ -199,7 +191,6 @@ def plot_sector_production_timeseries(
     )
 
     for row, period in enumerate(investment_periods):
-
         df = df_all.loc[period]
 
         if month:
@@ -213,9 +204,7 @@ def plot_sector_production_timeseries(
             df = df.rename(columns=n.carriers.nice_name.to_dict())
 
         try:
-
             if nrows > 1:
-
                 df.plot(kind="area", ax=axs[row], color=colors)
                 axs[row].set_xlabel("")
                 axs[row].set_ylabel(y_label)
@@ -223,7 +212,6 @@ def plot_sector_production_timeseries(
                 axs[row].tick_params(axis="x", labelrotation=45)
 
             else:
-
                 df.plot(kind="area", ax=axs, color=colors)
                 axs.set_xlabel("")
                 axs.set_ylabel(y_label)
@@ -254,7 +242,6 @@ def plot_transportation_production_timeseries(
     """
     Plots timeseries production as area chart.
     """
-
     assert sector == "trn"
 
     def _filter_vehicle_type(df: pd.DataFrame, vehicle: str) -> pd.DataFrame:
@@ -293,14 +280,12 @@ def plot_transportation_production_timeseries(
         return fig, axs
 
     for row, period in enumerate(investment_periods):
-
         df_veh_period = df_veh.loc[period]
 
         if month:
             df_veh_period = df_veh_period[df_veh_period.index.get_level_values("timestep").month == month_i].copy()
 
         for i, unit in enumerate(diff_units):
-
             all_modes = [x.name for x in modes]
             modes_per_unit = [modes[x].value for x in all_modes if units[x].value == unit]
 
@@ -310,16 +295,13 @@ def plot_transportation_production_timeseries(
                 df = df.rename(columns=n.carriers.nice_name.to_dict())
 
             try:
-
                 if nrows > 1:
-
                     df.plot(kind="area", ax=axs[row + i], color=colors)
                     axs[row + i].set_xlabel("")
                     axs[row + i].set_ylabel(f"{unit}")
                     axs[row + i].tick_params(axis="x", labelrotation=45)
 
                 else:
-
                     df.plot(kind="area", ax=axs, color=colors)
                     axs.set_xlabel("")
                     axs.set_ylabel(f"{unit}")
@@ -343,7 +325,6 @@ def plot_sector_production(
     """
     Plots model period production as bar chart.
     """
-
     y_label = kwargs.get("ylabel", "MWh")
 
     assert sector in ("res", "com", "ind", "pwr", "trn")
@@ -361,7 +342,6 @@ def plot_sector_production(
     df_all = get_sector_production_timeseries_by_carrier(n, sector=sector, state=state)
 
     for row, period in enumerate(investment_periods):
-
         df = df_all.loc[period].sum(axis=0)
 
         if df.empty:
@@ -372,9 +352,7 @@ def plot_sector_production(
             df.index = df.index.map(n.carriers.nice_name)
 
         try:
-
             if nrows > 1:
-
                 df.plot.bar(ax=axs[row])
                 axs[row].set_xlabel("")
                 axs[row].set_ylabel(y_label)
@@ -382,7 +360,6 @@ def plot_sector_production(
                 axs[row].tick_params(axis="x", labelrotation=45)
 
             else:
-
                 df.plot.bar(ax=axs)
                 axs.set_xlabel("")
                 axs.set_ylabel(y_label)
@@ -402,7 +379,6 @@ def plot_sector_emissions(
     """
     Plots model period emissions by sector.
     """
-
     investment_period = n.investment_periods[0]
 
     sectors = ("res", "com", "ind", "trn", "pwr", "ch4")
@@ -410,7 +386,6 @@ def plot_sector_emissions(
     data = []
 
     for sector in sectors:
-
         df = get_emission_timeseries_by_sector(n, sector, state=state)
 
         if df.empty:
@@ -452,7 +427,6 @@ def plot_state_emissions(
     """
     Plots stacked bar plot of state level emissions.
     """
-
     investment_period = n.investment_periods[0]
 
     fig, axs = plt.subplots(
@@ -485,7 +459,6 @@ def plot_capacity_by_carrier(
     """
     Bar plot of capacity by carrier.
     """
-
     investment_periods = n.investment_periods
 
     nrows = len(investment_periods)
@@ -500,7 +473,6 @@ def plot_capacity_by_carrier(
     df_all = df_all.reset_index()[["carrier", "p_nom_opt"]]
 
     for row, _ in enumerate(investment_periods):
-
         df = df_all.copy()
 
         if df.empty:
@@ -513,9 +485,7 @@ def plot_capacity_by_carrier(
         df = df.groupby("carrier").sum()
 
         try:
-
             if nrows > 1:
-
                 df.plot(kind="bar", stacked=False, ax=axs[row])
                 axs[row].set_xlabel("")
                 axs[row].set_ylabel("Capacity (MW)")
@@ -523,7 +493,6 @@ def plot_capacity_by_carrier(
                 axs[row].tick_params(axis="x", labelrotation=45)
 
             else:
-
                 df.plot(kind="bar", stacked=False, ax=axs)
                 axs.set_xlabel("")
                 axs.set_ylabel("Capacity (MW)")
@@ -577,7 +546,6 @@ def plot_transportation_capacity_by_carrier(
     )
 
     for row, _ in enumerate(investment_periods):
-
         df = df_veh.copy()
 
         if df.empty:
@@ -587,7 +555,6 @@ def plot_transportation_capacity_by_carrier(
         df["mode"] = df.carrier.map(lambda x: x.split("-")[-1])
 
         for i, unit in enumerate(diff_units):
-
             all_modes = [x.name for x in modes]
             modes_per_unit = [modes[x].value for x in all_modes if units[x].value == unit]
 
@@ -599,9 +566,7 @@ def plot_transportation_capacity_by_carrier(
             df_mode = df_mode.groupby("carrier").sum()
 
             try:
-
                 if nrows > 1:
-
                     df_mode.plot(kind="bar", stacked=False, ax=axs[row + i])
                     axs[row + i].set_xlabel("")
                     axs[row + i].set_ylabel(f"Capacity ({unit})")
@@ -609,7 +574,6 @@ def plot_transportation_capacity_by_carrier(
                     axs[row + i].tick_params(axis="x", labelrotation=45)
 
                 else:
-
                     df_mode.plot(kind="bar", stacked=False, ax=axs)
                     axs.set_xlabel("")
                     axs.set_ylabel(f"Capacity ({unit})")
@@ -633,7 +597,6 @@ def plot_capacity_per_node(
     """
     Plots capacity percentage per node.
     """
-
     sectors = get_sectors(n)
 
     nrows = len(sectors)
@@ -651,7 +614,6 @@ def plot_capacity_per_node(
     colors = get_plotting_colors(n, nice_name)
 
     for i, sector in enumerate(sectors):
-
         df = get_capacity_per_node(n, sector=sector, state=state)
         df = df.reset_index()[["node", "carrier", data_col]]
 
@@ -661,16 +623,13 @@ def plot_capacity_per_node(
         df = df.pivot(columns="carrier", index="node", values=data_col)
 
         try:
-
             if nrows > 1:
-
                 df.plot(kind="bar", stacked=True, ax=axs[i], color=colors)
                 axs[i].set_xlabel("")
                 axs[i].set_ylabel(y_label)
                 axs[i].set_title(f"{sector} Capacity")
 
             else:
-
                 df.plot(kind="bar", stacked=True, ax=axs, color=colors)
                 axs.set_xlabel("")
                 axs.set_ylabel(y_label)
@@ -692,7 +651,6 @@ def plot_capacity_brownfield(
     """
     Plots old and new capacity at a state level by carrier.
     """
-
     investment_periods = n.investment_periods
 
     nrows = len(investment_periods)
@@ -706,7 +664,6 @@ def plot_capacity_brownfield(
     y_label = "Capacity (MW)"
 
     for row, _ in enumerate(investment_periods):
-
         df = get_capacity_per_node(n, sector, state)
 
         if nice_name:
@@ -717,9 +674,7 @@ def plot_capacity_brownfield(
         df = df.reset_index()[["carrier", "existing", "new"]].groupby("carrier").sum()
 
         try:
-
             if nrows > 1:
-
                 df.plot(kind="bar", ax=axs[row])
                 axs[row].set_xlabel("")
                 axs[row].set_ylabel(y_label)
@@ -727,7 +682,6 @@ def plot_capacity_brownfield(
                 axs.tick_params(axis="x", labelrotation=45)
 
             else:
-
                 df.plot(kind="bar", ax=axs)
                 axs.set_xlabel("")
                 axs.set_ylabel(y_label)
@@ -781,7 +735,6 @@ def plot_transportation_capacity_brownfield(
     )
 
     for row, _ in enumerate(investment_periods):
-
         df = df_veh.copy()
 
         if df.empty:
@@ -791,7 +744,6 @@ def plot_transportation_capacity_brownfield(
         df["mode"] = df.carrier.map(lambda x: x.split("-")[-1])
 
         for i, unit in enumerate(diff_units):
-
             all_modes = [x.name for x in modes]
             modes_per_unit = [modes[x].value for x in all_modes if units[x].value == unit]
 
@@ -803,9 +755,7 @@ def plot_transportation_capacity_brownfield(
             df_mode = df_mode.groupby("carrier").sum()
 
             try:
-
                 if nrows > 1:
-
                     df_mode.plot(kind="bar", stacked=False, ax=axs[row + i])
                     axs[row + i].set_xlabel("")
                     axs[row + i].set_ylabel(f"Capacity ({unit})")
@@ -813,7 +763,6 @@ def plot_transportation_capacity_brownfield(
                     axs[row + i].tick_params(axis="x", labelrotation=45)
 
                 else:
-
                     df_mode.plot(kind="bar", stacked=False, ax=axs)
                     axs.set_xlabel("")
                     axs.set_ylabel(f"Capacity ({unit})")
@@ -835,7 +784,6 @@ def plot_sector_load_factor_timeseries(
     """
     Plots timeseries of load factor resampled to days.
     """
-
     investment_period = n.investment_periods[0]
 
     sectors = ("res", "com", "ind")
@@ -853,23 +801,19 @@ def plot_sector_load_factor_timeseries(
     col = 0
 
     for i, sector in enumerate(sectors):
-
         row = i // 2
         col = i % 2
 
         df = get_load_factor_timeseries(n, sector, state=state).loc[investment_period].resample("d").mean().dropna()
 
         try:
-
             if nrows > 1:
-
                 df.plot(ax=axs[row, col])
                 axs[row, col].set_xlabel("")
                 axs[row, col].set_ylabel("Load Factor (%)")
                 axs[row, col].set_title(f"{sector}")
 
             else:
-
                 df.plot(ax=axs[i])
                 axs[i].set_xlabel("")
                 axs[i].set_ylabel("Load Factor (%)")
@@ -891,7 +835,6 @@ def plot_sector_load_factor_boxplot(
     """
     Plots boxplot of load factors.
     """
-
     assert sector in ("res", "com", "ind")
 
     investment_periods = n.investment_periods
@@ -907,7 +850,6 @@ def plot_sector_load_factor_boxplot(
     df_all = get_load_factor_timeseries(n, sector, state=state)
 
     for row, period in enumerate(investment_periods):
-
         df = df_all.loc[period]
 
         if nice_name:
@@ -917,9 +859,7 @@ def plot_sector_load_factor_boxplot(
             )
 
         try:
-
             if nrows > 1:
-
                 sns.boxplot(df, ax=axs[row])
                 axs[row].set_xlabel("")
                 axs[row].set_ylabel("Load Factor (%)")
@@ -927,7 +867,6 @@ def plot_sector_load_factor_boxplot(
                 axs[row].tick_params(axis="x", labelrotation=45)
 
             else:
-
                 sns.boxplot(df, ax=axs)
                 axs.set_xlabel("")
                 axs.set_ylabel("Load Factor (%)")
@@ -947,7 +886,6 @@ def plot_sector_load_timeseries(
     state: Optional[str] = None,
     **kwargs,
 ) -> tuple:
-
     investment_period = n.investment_periods[0]
 
     df = get_end_use_load_timeseries(n, sector, sns_weight=False, state=state).loc[investment_period].T
@@ -967,7 +905,6 @@ def plot_sector_load_timeseries(
     )
 
     for i, load in enumerate(loads):
-
         l = df[load]
 
         # sns.lineplot(l, ax=axs[i], legend=False)
@@ -977,7 +914,6 @@ def plot_sector_load_timeseries(
         # palette = sns.color_palette(["lightgray"])
 
         try:
-
             sns.lineplot(
                 l,
                 color="lightgray",
@@ -1003,7 +939,6 @@ def plot_sector_load_bar(
     state: Optional[str] = None,
     **kwargs,
 ) -> tuple:
-
     investment_period = n.investment_periods[0]
 
     sectors = ("res", "com", "ind")
@@ -1022,7 +957,6 @@ def plot_sector_load_bar(
     title = state if state else "System"
 
     for i, sector in enumerate(sectors):
-
         row = i // 2
         col = i % 2
 
@@ -1033,20 +967,17 @@ def plot_sector_load_bar(
             continue
 
         try:
-
             if nrows > 1:
-
                 df.T.plot.bar(ax=axs[row, col])
                 axs[row, col].set_xlabel("")
-                axs[row, col].set_ylabel(f"Load (MWh)")
+                axs[row, col].set_ylabel("Load (MWh)")
                 axs[row, col].set_title(f"{title} {SECTOR_MAPPER[sector]}")
                 axs[row, col].tick_params(axis="x", labelrotation=0)
 
             else:
-
                 df.T.plot.bar(ax=axs[i])
                 axs[i].set_xlabel("")
-                axs[i].set_ylabel(f"Load (MWh)")
+                axs[i].set_ylabel("Load (MWh)")
                 axs[i].set_title(f"{title} {SECTOR_MAPPER[sector]}")
                 axs[i].tick_params(axis="x", labelrotation=0)
 
@@ -1066,7 +997,6 @@ def plot_sector_dr_timeseries(
     month: Optional[int] = None,
     **kwargs,
 ) -> tuple:
-
     e = get_storage_level_timeseries_carrier(
         n,
         sector,
@@ -1090,7 +1020,6 @@ def plot_sector_dr_timeseries(
     )
 
     for row, period in enumerate(investment_periods):
-
         df = e.loc[period]
 
         if month:
@@ -1104,9 +1033,7 @@ def plot_sector_dr_timeseries(
             df = df.rename(columns=n.carriers.nice_name.to_dict())
 
         try:
-
             if nrows > 1:
-
                 df.plot.line(ax=axs[row])
                 axs[row].set_xlabel("")
                 axs[row].set_ylabel(y_label)
@@ -1114,7 +1041,6 @@ def plot_sector_dr_timeseries(
                 axs[row].tick_params(axis="x", labelrotation=45)
 
             else:
-
                 df.plot.line(ax=axs)
                 axs.set_xlabel("")
                 axs.set_ylabel(y_label)
@@ -1133,7 +1059,6 @@ def plot_consumption(
     nice_name: Optional[bool] = True,
     **kwargs,
 ) -> tuple:
-
     assert sector in ("res", "com", "ind", "trn")
 
     investment_periods = n.investment_periods
@@ -1151,7 +1076,6 @@ def plot_consumption(
     df_all = get_end_use_consumption(n, sector, state)
 
     for row, period in enumerate(investment_periods):
-
         df = df_all.loc[period]
 
         if nice_name:
@@ -1160,16 +1084,13 @@ def plot_consumption(
         df = df.sum(axis=0).to_frame()
 
         try:
-
             if nrows > 1:
-
                 df.plot(kind="bar", ax=axs[row], legend=False)
                 axs[row].set_xlabel("")
                 axs[row].set_ylabel(y_label)
                 axs[row].tick_params(axis="x", labelrotation=45)
 
             else:
-
                 df.plot(kind="bar", ax=axs)
                 axs.set_xlabel("")
                 axs.set_ylabel(y_label)
@@ -1197,7 +1118,6 @@ def save_fig(
     """
     Saves the result figure.
     """
-
     fig, _ = fn(n, **kwargs)
 
     if not wildcards:
@@ -1606,7 +1526,6 @@ if __name__ == "__main__":
     # plot at system level
 
     for plot_data in plotting_data:
-
         fn = plot_data.fn
         title = plot_data.nice_name if plot_data.nice_name else plot_data.name
 
@@ -1649,7 +1568,6 @@ if __name__ == "__main__":
         months = {month.value: _get_month_name(month) for month in Month}
 
         for month_i, month_name in months.items():
-
             if plot_data.sector:
                 f_path = Path(
                     results_dir,
@@ -1678,12 +1596,10 @@ if __name__ == "__main__":
     # plot each state
 
     for plot_data in plotting_data:
-
         fn = plot_data.fn
         title = plot_data.nice_name if plot_data.nice_name else plot_data.name
 
         for state in states:
-
             if plot_data.fn_kwargs:
                 fn_kwargs = plot_data.fn_kwargs
             else:
@@ -1724,7 +1640,6 @@ if __name__ == "__main__":
         months = {month.value: _get_month_name(month) for month in Month}
 
         for month_i, month_name in months.items():
-
             if plot_data.sector:
                 f_path = Path(
                     results_dir,

--- a/workflow/scripts/plot_validation_production.py
+++ b/workflow/scripts/plot_validation_production.py
@@ -337,7 +337,6 @@ def plot_regional_comparisons(
     buses = n.buses.copy()
 
     if snakemake.config["model_topology"]["topological_boundaries"] == "reeds_zone":
-
         regions = n.buses.reeds_ba.unique()
         regions = list(OrderedDict.fromkeys(regions))
         buses["region"] = buses.reeds_ba
@@ -418,7 +417,6 @@ def plot_load_shedding_map(
     regions: gpd.GeoDataFrame,
     **wildcards,
 ):
-
     load_curtailment = n.generators_t.p.filter(regex="^(.*load).*$")
     load_curtailment_sum = load_curtailment.sum() / 1e3  # convert to MW
 

--- a/workflow/scripts/plot_validation_sector.py
+++ b/workflow/scripts/plot_validation_sector.py
@@ -3,19 +3,17 @@ Plots sector validation plots.
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
-from enum import Enum
-from math import ceil
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 import matplotlib.pyplot as plt
 import pandas as pd
 import pypsa
-import seaborn as sns
 from _helpers import configure_logging, mock_snakemake
 from add_electricity import sanitize_carriers
-from constants import STATE_2_CODE, Month
+from constants import STATE_2_CODE
 from plot_statistics import create_title
 from summary_natural_gas import get_historical_ng_prices, get_ng_price
 from summary_sector import (
@@ -69,7 +67,6 @@ def plot_sector_emissions_validation(
     """
     Plots state by state sector emission comparison.
     """
-
     investment_period = n.investment_periods[0]
 
     historical = get_historical_emissions(
@@ -98,7 +95,7 @@ def plot_sector_emissions_validation(
     historical = historical.T
 
     for sector in modelled.columns:
-        if not sector in historical.columns:
+        if sector not in historical.columns:
             historical[sector] = 0
     assert set(historical.columns) == set(modelled.columns)
 
@@ -106,23 +103,20 @@ def plot_sector_emissions_validation(
     historical = historical.T
 
     if state:  # plot at state level
-
         historical = historical[state].to_frame("Actual")
         modelled = modelled[state].to_frame("Modelled")
 
     else:  # plot at system level
-
         historical = historical[modelled.columns].sum(axis=1).to_frame("Actual")
         modelled = modelled.sum(axis=1).to_frame("Modelled")
 
     df = historical.join(modelled)
 
     try:
-
         df.plot.bar(ax=axs, stacked=False)
         axs.set_xlabel("")
         axs.set_ylabel("Emissions (MT)")
-        axs.set_title(f"Emissions by Sector")
+        axs.set_title("Emissions by Sector")
         axs.tick_params(axis="x", labelrotation=0)
 
     except TypeError:  # no numeric data to plot
@@ -140,7 +134,6 @@ def plot_state_emissions_validation(
     """
     Plots total state emission comparison.
     """
-
     investment_period = n.investment_periods[0]
 
     historical = get_historical_emissions(
@@ -195,7 +188,6 @@ def plot_system_emissions_validation_by_state(
     """
     Plots all states modelled and historcal.
     """
-
     investment_period = n.investment_periods[0]
 
     historical = get_historical_emissions(
@@ -239,7 +231,6 @@ def plot_sector_consumption_validation(
     """
     Plots sector energy consumption comparison.
     """
-
     investment_period = n.investment_periods[0]
 
     historical = get_historical_end_use_consumption(
@@ -303,7 +294,6 @@ def plot_power_generation_validation(
     state: Optional[str] = None,
     **kwargs,
 ) -> tuple:
-
     investment_period = n.investment_periods[0]
 
     modelled = _get_annual_generation(n, investment_period, state)
@@ -343,7 +333,6 @@ def plot_ng_price_validation(
     state: Optional[str] = None,
     **kwargs,
 ) -> tuple:
-
     investment_period = n.investment_periods[0]
 
     modelled = get_ng_price(n)
@@ -410,7 +399,6 @@ def plot_transportation_by_mode_validation(
     state: Optional[str] = None,
     **kwargs,
 ) -> tuple:
-
     # to pull in from snakemake inputs
     transport_ratios = {
         "Alabama": 2.05,
@@ -504,10 +492,9 @@ def plot_transportation_by_mode_validation(
     data = data.join(modelled.to_frame(name="modelled")).fillna(0)
 
     try:
-
         data.plot.bar(ax=axs)
         axs.set_xlabel("")
-        axs.set_ylabel(f"Energy Consumption by Transport Mode (MWh)")
+        axs.set_ylabel("Energy Consumption by Transport Mode (MWh)")
         axs.tick_params(axis="x", labelrotation=45)
 
     except TypeError:  # no numeric data to plot
@@ -521,7 +508,6 @@ def plot_system_consumption_validation_by_state(
     eia_api: str,
     **kwargs,
 ) -> tuple:
-
     states = [x for x in n.buses.STATE.unique() if x]  # remove non-classified buses
 
     sectors = ("res", "com", "ind", "trn")
@@ -537,7 +523,6 @@ def plot_system_consumption_validation_by_state(
     y_label = "Energy (MWh)"
 
     for i, sector in enumerate(sectors):
-
         historical = get_historical_end_use_consumption(
             SECTOR_MAPPER[sector],
             2020,
@@ -556,16 +541,13 @@ def plot_system_consumption_validation_by_state(
         )
 
         try:
-
             if nrows > 1:
-
                 df.plot(kind="bar", ax=axs[i])
                 axs[i].set_xlabel("")
                 axs[i].set_ylabel(y_label)
                 axs[i].set_title(f"{sector} Production")
 
             else:
-
                 df.plot(kind="bar", ax=axs)
                 axs.set_xlabel("")
                 axs.set_ylabel(y_label)
@@ -654,7 +636,6 @@ def save_fig(
     """
     Saves the result figure.
     """
-
     fig, _ = fn(n, **kwargs)
 
     if not wildcards:
@@ -708,7 +689,6 @@ if __name__ == "__main__":
     plotting_data = _initialize_metadata(VALIDATION_PLOTS)
 
     for plot_data in plotting_data:
-
         fn = plot_data.fn
         title = plot_data.nice_name if plot_data.nice_name else plot_data.name
 
@@ -749,7 +729,6 @@ if __name__ == "__main__":
             continue
 
         for state in states:
-
             if plot_data.fn_kwargs:
                 fn_kwargs = plot_data.fn_kwargs
             else:

--- a/workflow/scripts/prepare_network.py
+++ b/workflow/scripts/prepare_network.py
@@ -67,8 +67,6 @@ from _helpers import (
     set_scenario_config,
     update_config_from_wildcards,
 )
-from add_electricity import update_transmission_costs
-from pypsa.descriptors import expand_series
 
 idx = pd.IndexSlice
 

--- a/workflow/scripts/retrieve_caiso_data.py
+++ b/workflow/scripts/retrieve_caiso_data.py
@@ -31,7 +31,6 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 import requests
-import seaborn as sns
 
 
 def download_oasis_report(
@@ -53,7 +52,8 @@ def download_oasis_report(
     - node: Specific fuel region ID or 'ALL' for all regions.
     - resultformat: Format of the result ('6' for CSV, '5' for XML).
 
-    Returns:
+    Returns
+    -------
     - None. Downloads the file to the current directory.
     """
     base_url = "http://oasis.caiso.com/oasisapi/SingleZip"
@@ -147,7 +147,8 @@ def get_files_starting_with(folder_path, prefix):
     - folder_path: Path to the folder.
     - prefix: The string that the file names should start with.
 
-    Returns:
+    Returns
+    -------
     - A list of file names that start with the specified prefix.
     """
     file_names = []
@@ -199,7 +200,6 @@ def reduce_select_pricing_nodes(combined_data_merged):
 
 
 def main(snakemake):
-
     fuel_year = snakemake.params.fuel_year
 
     file_names = step_download_oasis_reports(

--- a/workflow/scripts/retrieve_egs.py
+++ b/workflow/scripts/retrieve_egs.py
@@ -1,12 +1,7 @@
-import io
 import logging
-import os
-import platform
-import subprocess
 import zipfile
 from pathlib import Path
 
-import requests
 from _helpers import configure_logging, progress_retrieve
 
 logger = logging.getLogger(__name__)

--- a/workflow/scripts/retrieve_eulp.py
+++ b/workflow/scripts/retrieve_eulp.py
@@ -1,7 +1,8 @@
 """
 Module to download end use load profiles (eulp) for comstock and restock data.
 
-Notes:
+Notes
+-----
     - Downloaded at state level
     - Multisector 15-min load profiles for a year (ie. lots of data)
     - Locked to 2018 Amy Weather data
@@ -10,10 +11,8 @@ Notes:
 
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
-import constants
-import pandas as pd
 import requests
 from _helpers import configure_logging
 
@@ -63,7 +62,6 @@ class OediDownload:
         """
         Gets html of folder.
         """
-
         if self.stock == "res":
             data_folder = f"resstock_amy2018_release_{self.release}"
         elif self.stock == "com":
@@ -77,7 +75,6 @@ class OediDownload:
         buildings: str | list[str],
         upgrade: int = 0,
     ) -> list[str]:
-
         folder = self._get_html_folder(state)
 
         if isinstance(buildings, str):
@@ -92,7 +89,6 @@ class OediDownload:
         return htmls
 
     def _request_data(self, url: str, save: str) -> dict[str, dict | str]:
-
         response = requests.get(url)
         if response.status_code == 200:
             logger.info(f"Writing {save}")
@@ -118,7 +114,6 @@ class OediDownload:
         """
         Public method to interface with.
         """
-
         if not directory:
             directory = f"{state}"
         else:
@@ -141,7 +136,6 @@ class OediDownload:
 
 
 if __name__ == "__main__":
-
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 

--- a/workflow/scripts/retrieve_gridemissions_data.py
+++ b/workflow/scripts/retrieve_gridemissions_data.py
@@ -10,13 +10,11 @@ Historical electrical generation, demand, interchange, and emissions data are re
 """
 
 import glob
-import gzip
 import logging
 import os
 import re
 import tarfile
 import warnings
-from io import BytesIO
 from pathlib import Path
 
 import pandas as pd
@@ -103,7 +101,7 @@ if __name__ == "__main__":
 
     grid_emissions_data_url = "https://gridemissions.s3.us-east-2.amazonaws.com/processed.tar.gz"
 
-    PATH_DOWNLOAD = Path(f"data/GridEmissions")
+    PATH_DOWNLOAD = Path("data/GridEmissions")
     PATH_DOWNLOAD.mkdir(parents=True, exist_ok=True)
     download_and_extract(grid_emissions_data_url, PATH_DOWNLOAD)
     df_elec = prepare_historical_data(PATH_DOWNLOAD, suffix="elec")

--- a/workflow/scripts/retrieve_pudl.py
+++ b/workflow/scripts/retrieve_pudl.py
@@ -4,12 +4,9 @@ Retrieves PUDL data.
 
 import logging
 import zipfile
-import zlib
 from pathlib import Path
 
-import requests
 from _helpers import mock_snakemake, progress_retrieve
-from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +37,7 @@ if __name__ == "__main__":
             zip_ref.extractall(Path(save_pudl).parent)
 
     # Get PUDL FERC Form 714 Parquet
-    parquet = f"https://zenodo.org/records/11292273/files/out_ferc714__hourly_estimated_state_demand.parquet?download=1"
+    parquet = "https://zenodo.org/records/11292273/files/out_ferc714__hourly_estimated_state_demand.parquet?download=1"
 
     save_ferc = snakemake.output.pudl_ferc714
 

--- a/workflow/scripts/scenario_comparison.py
+++ b/workflow/scripts/scenario_comparison.py
@@ -65,7 +65,6 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pypsa
-import seaborn as sns
 import yaml
 from matplotlib import pyplot as plt
 

--- a/workflow/scripts/simplify_network.py
+++ b/workflow/scripts/simplify_network.py
@@ -39,7 +39,8 @@ def convert_to_voltage_level(n, new_voltage):
     """
     Converts network.lines parameters to a given voltage.
 
-    Parameters:
+    Parameters
+    ----------
     n (pypsa.Network): Network
     new_voltage (float): New voltage level
     """
@@ -101,7 +102,6 @@ def aggregate_to_substations(
     First step in clusterings, if use_ba_zones is True, then the network
     retains balancing Authority zones in clustering.
     """
-
     logger.info("Aggregating buses to substation level...")
 
     generator_strategies = aggregation_strategies.get("generators", dict())

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -62,7 +62,8 @@ def filter_components(n, component_type, planning_horizon, carrier_list, region_
     """
     Filter components based on common criteria.
 
-    Parameters:
+    Parameters
+    ----------
     - n: pypsa.Network
         The PyPSA network object.
     - component_type: str
@@ -76,7 +77,8 @@ def filter_components(n, component_type, planning_horizon, carrier_list, region_
     - extendable: bool, optional
         If specified, filters by extendable or non-extendable assets.
 
-    Returns:
+    Returns
+    -------
     - pd.DataFrame
         Filtered assets.
     """
@@ -285,7 +287,6 @@ def add_technology_capacity_target_constraints(n, config):
             target["min"] = lhs_extendable
 
         if not np.isnan(target["min"]):
-
             n.model.add_constraints(
                 lhs >= (target["min"]),
                 name=f"GlobalConstraint-{target.name}_{target.planning_horizon}_min",
@@ -610,7 +611,6 @@ def add_regional_co2limit(n, sns, config):
     """
     Adding regional regional CO2 Limits Specified in the config.yaml.
     """
-
     regional_co2_lims = pd.read_csv(
         config["electricity"]["regional_Co2_limits"],
         index_col=[0],
@@ -911,7 +911,6 @@ def add_sector_co2_constraints(n, config):
     """
 
     def apply_total_state_limit(n, year, state, value):
-
         sns = n.snapshots
         snapshot = sns[sns.get_level_values("period") == year][-1]
 
@@ -931,7 +930,6 @@ def add_sector_co2_constraints(n, config):
         )
 
     def apply_sector_state_limit(n, year, state, sector, value):
-
         sns = n.snapshots
         snapshot = sns[sns.get_level_values("period") == year][-1]
 
@@ -951,7 +949,6 @@ def add_sector_co2_constraints(n, config):
         )
 
     def apply_total_national_limit(n, year, value):
-
         sns = n.snapshots
         snapshot = sns[sns.get_level_values("period") == year][-1]
 
@@ -968,7 +965,6 @@ def add_sector_co2_constraints(n, config):
         )
 
     def apply_sector_national_limit(n, year, sector, value):
-
         sns = n.snapshots
         snapshot = sns[sns.get_level_values("period") == year][-1]
 
@@ -1001,12 +997,10 @@ def add_sector_co2_constraints(n, config):
     sectors = df.sector.unique()
 
     for sector in sectors:
-
         df_sector = df[df.sector == sector]
         states = df_sector.state.unique()
 
         for state in states:
-
             df_state = df_sector[df_sector.state == state]
             years = [x for x in df_state.year.unique() if x in n.investment_periods]
 
@@ -1017,7 +1011,6 @@ def add_sector_co2_constraints(n, config):
                 continue
 
             for year in years:
-
                 df_limit = df_state[df_state.year == year].reset_index(drop=True)
                 assert df_limit.shape[0] == 1
 
@@ -1025,14 +1018,12 @@ def add_sector_co2_constraints(n, config):
                 value = df_limit.loc[0, "co2_limit_mmt"] * 1e6
 
                 if state.upper() == "USA":
-
                     if sector == "all":
                         apply_total_national_limit(n, year, value)
                     else:
                         apply_sector_national_limit(n, year, sector, value)
 
                 else:
-
                     if sector == "all":
                         apply_total_state_limit(n, year, state, value)
                     else:
@@ -1057,7 +1048,6 @@ def add_cooling_heat_pump_constraints(n, config):
     """
 
     def add_hp_capacity_constraint(n, hp_type):
-
         assert hp_type in ("ashp", "gshp")
 
         heating_hps = n.links[n.links.index.str.endswith(hp_type)].index
@@ -1073,7 +1063,6 @@ def add_cooling_heat_pump_constraints(n, config):
         n.model.add_constraints(lhs == rhs, name=f"Link-{hp_type}_cooling_capacity")
 
     def add_hp_generation_constraint(n, hp_type):
-
         heating_hps = n.links[n.links.index.str.endswith(hp_type)].index
         if heating_hps.empty:
             return
@@ -1116,7 +1105,6 @@ def add_gshp_capacity_constraint(n, config):
     - The constraint is: [ASHP - (urban / rural) * GSHP >= 0]
     - ie. for every unit of GSHP, we need to install 3 units of ASHP
     """
-
     pop = pd.read_csv(snakemake.input.pop_layout)
     pop["urban_rural_fraction"] = (pop.urban_fraction / pop.rural_fraction).round(2)
     fraction = pop.set_index("name")["urban_rural_fraction"].to_dict()
@@ -1137,11 +1125,10 @@ def add_gshp_capacity_constraint(n, config):
     lhs = ashp_capacity - gshp_capacity.mul(gshp_multiplier.values)
     rhs = 0
 
-    n.model.add_constraints(lhs >= rhs, name=f"Link-gshp_capacity_ratio")
+    n.model.add_constraints(lhs >= rhs, name="Link-gshp_capacity_ratio")
 
 
 def add_ng_import_export_limits(n, config):
-
     def _format_link_name(s: str) -> str:
         states = s.split("-")
         return f"{states[0]} {states[1]} gas"
@@ -1150,7 +1137,6 @@ def add_ng_import_export_limits(n, config):
         prod: pd.DataFrame,
         link_suffix: Optional[str] = None,
     ) -> pd.DataFrame:
-
         df = prod.copy()
         df["link"] = df.state.map(_format_link_name)
         if link_suffix:
@@ -1165,7 +1151,6 @@ def add_ng_import_export_limits(n, config):
         """
         Sets gas import limit over each year.
         """
-
         assert constraint in ("max", "min")
 
         if not multiplier:
@@ -1199,7 +1184,6 @@ def add_ng_import_export_limits(n, config):
         """
         Sets maximum export limit over the year.
         """
-
         assert constraint in ("max", "min")
 
         if not multiplier:
@@ -1291,14 +1275,12 @@ def add_water_heater_constraints(n, config):
     """
     Adds constraint so energy to meet water demand must flow through store.
     """
-
     links = n.links[(n.links.index.str.contains("-water-")) & (n.links.index.str.contains("-discharger"))]
 
     link_names = links.index
     store_names = [x.replace("-discharger", "") for x in links.index]
 
     for period in n.investment_periods:
-
         # first snapshot does not respect constraint
         e_previous = n.model["Store-e"].loc[period, store_names]
         e_previous = e_previous.roll(timestep=1)
@@ -1329,14 +1311,12 @@ def add_demand_response_constraints(n, config):
 
         No need to multiply out snapshot weights here
         """
-
         dr_links = n.links[n.links.carrier.str.endswith("-dr") & n.links.carrier.str.startswith(f"{sector}-")]
 
         if dr_links.empty:
             return
 
         if sector != "trn":
-
             deferrable_links = dr_links[dr_links.index.str.endswith("-dr-discharger")]
 
             deferrable_loads = deferrable_links.bus1.unique().tolist()
@@ -1355,7 +1335,6 @@ def add_demand_response_constraints(n, config):
         # transport dr is at the aggregation bus
         # sum all outgoing capacity and apply the capacity limit to that
         else:
-
             inflow_links = dr_links[dr_links.index.str.endswith("-dr-discharger")]
             inflow = n.model["Link-p"].loc[:, inflow_links.index].groupby(inflow_links.bus1).sum()
             inflow = inflow.rename({"bus1": "Bus"})  # align coordinate names
@@ -1369,7 +1348,7 @@ def add_demand_response_constraints(n, config):
 
             n.model.add_constraints(
                 lhs >= rhs,
-                name=f"demand_response_capacity-trn",
+                name="demand_response_capacity-trn",
             )
 
     # demand response addition starts here
@@ -1377,7 +1356,6 @@ def add_demand_response_constraints(n, config):
     sectors = ["res", "com", "ind", "trn"]
 
     for sector in sectors:
-
         if sector in ["res", "com"]:
             dr_config = config["sector"]["service_sector"].get("demand_response", {})
         elif sector == "trn":

--- a/workflow/scripts/summary.py
+++ b/workflow/scripts/summary.py
@@ -24,7 +24,6 @@ def get_primary_energy_use(n: pypsa.Network) -> pd.DataFrame:
     """
     Gets timeseries primary energy use by bus and carrier.
     """
-
     link_energy_use = (
         StatisticsAccessor(n)
         .withdrawal(
@@ -53,7 +52,8 @@ def get_primary_energy_use(n: pypsa.Network) -> pd.DataFrame:
     return (
         pd.concat([gen_energy_use, link_energy_use])
         # .reset_index() commenting this out seems to fix issue in multi-horizon indexing
-        .groupby(["bus", "carrier"]).sum()
+        .groupby(["bus", "carrier"])
+        .sum()
     )
 
 
@@ -185,9 +185,11 @@ def get_capacity_base(n: pypsa.Network) -> pd.DataFrame:
         if c.name in ("Generator", "StorageUnit"):
             totals.append((c.df.p_nom).groupby(by=[c.df.bus, c.df.carrier]).sum())
         elif c.name == "Link":
-            totals.append(
-                (c.df.p_nom).groupby(by=[c.df.bus0, c.df.carrier]).sum().rename_axis(index={"bus0": "bus"}),
-            ),
+            (
+                totals.append(
+                    (c.df.p_nom).groupby(by=[c.df.bus0, c.df.carrier]).sum().rename_axis(index={"bus0": "bus"}),
+                ),
+            )
             totals.append(
                 (c.df.p_nom).groupby(by=[c.df.bus1, c.df.carrier]).sum().rename_axis(index={"bus1": "bus"}),
             )
@@ -283,7 +285,6 @@ def get_fuel_costs(n: pypsa.Network) -> pd.DataFrame:
 
     Units are $/MWh
     """
-
     # approximates for 2030
     fixed_voms = {
         "coal": 8.18,
@@ -335,7 +336,6 @@ def get_node_emissions_timeseries(n: pypsa.Network) -> pd.DataFrame:
     """
     Gets timeseries emissions per node.
     """
-
     return (
         get_node_carrier_emissions_timeseries(n)
         .droplevel("carrier")
@@ -350,7 +350,6 @@ def get_tech_emissions_timeseries(n: pypsa.Network) -> pd.DataFrame:
     """
     Gets timeseries emissions per technology.
     """
-
     return (
         get_node_carrier_emissions_timeseries(n)
         .droplevel("bus")

--- a/workflow/scripts/summary_natural_gas.py
+++ b/workflow/scripts/summary_natural_gas.py
@@ -2,7 +2,6 @@
 Module for summarizing natural gas results.
 """
 
-from typing import List
 
 import constants
 import pandas as pd
@@ -30,7 +29,6 @@ def get_gas_demand(
 
     This in input energy required (ie. not applying efficiency losses)
     """
-
     data = {}
 
     buses = n.buses[n.buses.index.str.endswith(" gas")].index
@@ -56,7 +54,6 @@ def get_imports_exports(
     """
     Gets gas flow into and out of the state.
     """
-
     # catches any of the following codes at the start of the string
     regex = "(?:^|.{2})(?:MX|AB|BC|MB|NB|NL|NT|NS|NU|ON|PE|QC|SK|YT)"
 
@@ -104,7 +101,6 @@ def get_imports_exports(
     data = {}
 
     for state in states:
-
         data[state] = {}
 
         import_cols = [x for x in imports_t.columns if f"{state} " in x]
@@ -168,7 +164,6 @@ def get_ng_price(n: pypsa.Network) -> dict[str, pd.DataFrame]:
     """
     Gets state level natural gas price.
     """
-
     buses = n.buses[n.buses.carrier == "gas"]
     buses = n.buses_t.marginal_price[buses.index]
 

--- a/workflow/scripts/summary_sector.py
+++ b/workflow/scripts/summary_sector.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 #         case _:
 #             raise NotImplementedError
 
-# todo - pull this from config
+# TODO - pull this from config
 PWR_CARRIERS = [
     "nuclear",
     "oil",
@@ -129,7 +129,7 @@ def _filter_gens_on_sector(n: pypsa.Network, sector: str) -> pd.DataFrame:
 
 def _resample_data(df: pd.DataFrame, freq: str, agg_fn: callable) -> pd.DataFrame:
     if not callable(agg_fn):
-        f"Must provide resampling function in the form of 'pd.Series.sum'"
+        "Must provide resampling function in the form of 'pd.Series.sum'"
         return df
     else:
         return df.groupby("period").resample(freq, level="timestep").apply(agg_fn)
@@ -170,8 +170,7 @@ def _get_opt_capacity_per_node(
     include_elec: bool = False,
     state: Optional[str] = None,
 ) -> pd.Series:
-
-    assert not sector in ["pwr"]
+    assert sector not in ["pwr"]
 
     df = _filter_link_on_sector(n, sector)
 
@@ -203,7 +202,6 @@ def _get_opt_pwr_capacity_per_node(
     state: Optional[str] = None,
     **kwargs,
 ) -> pd.Series:
-
     links = _filter_link_on_sector(n, "pwr")
     gens = _filter_gens_on_sector(n, "pwr")
 
@@ -231,8 +229,7 @@ def _get_total_capacity_per_node(
     include_elec: bool = False,
     state: Optional[str] = None,
 ) -> pd.DataFrame:
-
-    assert not sector in ["pwr"]
+    assert sector not in ["pwr"]
 
     df = _filter_link_on_sector(n, sector)
 
@@ -262,7 +259,6 @@ def _get_total_pwr_capacity_per_node(
     state: Optional[str] = None,
     **kwargs,
 ) -> pd.DataFrame:
-
     links = _filter_link_on_sector(n, "pwr")
     gens = _filter_gens_on_sector(n, "pwr")
 
@@ -286,7 +282,6 @@ def _get_brownfield_pwr_capacity_per_node(
     state: Optional[str] = None,
     **kwargs,
 ) -> pd.DataFrame:
-
     links = _filter_link_on_sector(n, "pwr")
     gens = _filter_gens_on_sector(n, "pwr")
 
@@ -318,8 +313,7 @@ def _get_brownfield_capacity_per_node(
     state: Optional[str] = None,
     **kwargs,
 ) -> pd.DataFrame:
-
-    assert not sector in ["pwr"]
+    assert sector not in ["pwr"]
 
     df = _filter_link_on_sector(n, sector)
 
@@ -357,7 +351,6 @@ def get_capacity_per_node(
     state: Optional[str] = None,
     **kwargs,
 ) -> pd.DataFrame:
-
     if sector == "pwr":
         total = _get_total_pwr_capacity_per_node(
             n,
@@ -398,7 +391,6 @@ def get_sector_production_timeseries(
     Note: can not use statistics module as multi-output links for co2 tracking
     > n.statistics.supply("Link", nice_names=False, aggregate_time=False).T
     """
-
     links = _filter_link_on_sector(n, sector).index.to_list()
 
     if remove_sns_weights:
@@ -431,7 +423,6 @@ def get_power_production_timeseries(
     Note: can not use statistics module as multi-output links for co2 tracking
     > n.statistics.supply("Link", nice_names=False, aggregate_time=False).T
     """
-
     links = _filter_link_on_sector(n, "pwr").index.to_list()
     gens = _filter_gens_on_sector(n, "pwr").index.to_list()
 
@@ -467,7 +458,6 @@ def get_sector_production_timeseries_by_carrier(
     """
     Gets timeseries production by carrier.
     """
-
     if sector == "pwr":
         df = get_power_production_timeseries(
             n,
@@ -520,7 +510,6 @@ def get_load_factor_timeseries(
     include_elec: bool = False,
     state: Optional[str] = None,
 ) -> pd.DataFrame:
-
     max_prod = get_sector_max_production_timeseries(n, sector, state=state)
     act_prod = get_sector_production_timeseries(n, sector, state=state)
 
@@ -550,7 +539,7 @@ def get_emission_timeseries_by_sector(
     """
     if sector:
         if sector == "ch4":
-            stores_in_sector = [x for x in n.stores.index if f"gas-ch4" in x]
+            stores_in_sector = [x for x in n.stores.index if "gas-ch4" in x]
         else:
             stores_in_sector = [x for x in n.stores.index if f"{sector}-co2" in x]
     else:
@@ -572,7 +561,6 @@ def get_historical_emissions(
     """
     Emissions by state/sector in units of million metric tons.
     """
-
     dfs = []
 
     if isinstance(sectors, str):
@@ -596,7 +584,6 @@ def get_historical_end_use_consumption(
     """
     End-Use consumption by state/sector in units of MWh.
     """
-
     dfs = []
 
     if isinstance(sectors, str):
@@ -616,7 +603,6 @@ def get_historical_end_use_consumption(
 
 
 def get_historical_power_production(year: int, api: str) -> pd.DataFrame:
-
     fuel_mapper = {
         "BIO": "biomass",
         "COW": "coal",
@@ -710,7 +696,6 @@ def get_end_use_load_timeseries(
 
     - Residential, Commercial, Industrial are in untis of MWh
     """
-
     assert sector in ("res", "com", "ind")
 
     loads = n.loads[n.loads.carrier.str.startswith(sector)]
@@ -732,7 +717,6 @@ def get_storage_level_timeseries(
     state: Optional[str] = None,
     **kwargs,
 ) -> pd.DataFrame:
-
     stores = n.stores[n.stores.carrier.str.startswith(sector)]
 
     if state:
@@ -754,7 +738,6 @@ def get_storage_level_timeseries_carrier(
     resample_fn: Optional[callable] = None,
     **kwargs,
 ) -> pd.DataFrame:
-
     df = get_storage_level_timeseries(n, sector, remove_sns_weights, state)
     df = df.rename(columns=n.stores.carrier)
     df = df.T.groupby(level=0).sum().T
@@ -776,7 +759,6 @@ def get_end_use_load_timeseries_carrier(
 
     - Residential, Commercial, Industrial are in untis of MWh
     """
-
     df = get_end_use_load_timeseries(n, sector, sns_weight).T
     if state:
         buses = _get_loads_in_state(n, state)
@@ -801,7 +783,6 @@ def get_historical_transport_consumption_by_mode(api: str) -> pd.DataFrame:
     """
     Will return data in units of MWh.
     """
-
     vehicles = [
         "light_duty",
         "med_duty",


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
For windows OS, first use zipfile_deflate64 to unzip NREL EFS dataset. If failed then fallback to original codes. This solves the bug that NREL EFS dataset being not able to be unzipped.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
