### PR TITLE
Corrects `nan` in `efficiency2`

### DIFF
--- a/workflow/scripts/add_sectors.py
+++ b/workflow/scripts/add_sectors.py
@@ -234,10 +234,9 @@ def convert_generators_2_links(
     for param, df in pnl.items():
         n.links_t[param] = n.links_t[param].join(df, how="inner")
 
-    # remove generators
     n.mremove("Generator", plants.index)
 
-    # correct any efficiency2's from nan to 0
+    # existing links will give a 'nan in efficiency2' warning
     n.links["efficiency2"] = n.links.efficiency2.fillna(0)
 
 

--- a/workflow/scripts/add_sectors.py
+++ b/workflow/scripts/add_sectors.py
@@ -237,6 +237,9 @@ def convert_generators_2_links(
     # remove generators
     n.mremove("Generator", plants.index)
 
+    # correct any efficiency2's from nan to 0
+    n.links["efficiency2"] = n.links.efficiency2.fillna(0)
+
 
 def split_loads_by_carrier(n: pypsa.Network):
     """
@@ -303,8 +306,8 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "add_sectors",
             interconnect="western",
-            simpl="70",
-            clusters="4m",
+            simpl="132",
+            clusters="33m",
             ll="v1.0",
             opts="3h",
             sector="E-G",


### PR DESCRIPTION
Closes #540

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

When converting generators to links, an `efficiecny2` was added to support state level co2 tracking. This introduced `nan` values for existing links. This PR addresses these warnings. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
