### PR TITLE
Reference PUDL S3 Parquets instead of sqlite download, Lock PUDL version

### DIFF
--- a/workflow/repo_data/config/config.common.yaml
+++ b/workflow/repo_data/config/config.common.yaml
@@ -1,3 +1,5 @@
+pudl_path: s3://pudl.catalyst.coop/v2025.2.0
+
 foresight:  'perfect'
 # docs :
 renewable:

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -94,8 +94,8 @@ rule build_bus_regions:
 rule build_cost_data:
     params:
         costs=config_provider("costs"),
+        pudl_path=config_provider("pudl_path"),
     input:
-        pudl=DATA + "pudl/pudl.sqlite",
         efs_tech_costs="repo_data/costs/EFS_Technology_Data.xlsx",
         efs_icev_costs="repo_data/costs/efs_icev_costs.csv",
         eia_tech_costs="repo_data/costs/eia_tech_costs.csv",
@@ -303,9 +303,9 @@ def demand_scaling_data(wildcards):
         ].capitalize()
         return DATA + f"nrel_efs/EFSLoadProfile_{efs_case}_{efs_speed}.csv"
     elif profile == "eia":
-        return DATA + "pudl/pudl.sqlite"
+        return config_provider("pudl_path")
     elif profile == "ferc":
-        return DATA + "pudl/pudl.sqlite"
+        return config_provider("pudl_path")
     else:
         return ""
 
@@ -319,6 +319,7 @@ rule build_electrical_demand:
         profile_year=pd.to_datetime(config["snapshots"]["start"]).year,
         planning_horizons=config["scenario"]["planning_horizons"],
         snapshots=config["snapshots"],
+        pudl_path=config_provider("pudl_path"),
     input:
         network=RESOURCES + "{interconnect}/elec_base_network.nc",
         demand_files=demand_raw_data,
@@ -513,9 +514,9 @@ rule build_fuel_prices:
     params:
         snapshots=config["snapshots"],
         api_eia=config["api"]["eia"],
+        pudl_path=config_provider("pudl_path"),
     input:
         gas_balancing_area=ba_gas_dynamic_fuel_price_files,
-        pudl=DATA + "pudl/pudl.sqlite",
     output:
         state_ng_fuel_prices=RESOURCES + "{interconnect}/state_ng_power_prices.csv",
         state_coal_fuel_prices=RESOURCES + "{interconnect}/state_coal_power_prices.csv",
@@ -547,8 +548,10 @@ def dynamic_fuel_price_files(wildcards):
 
 
 rule build_powerplants:
+    params:
+        pudl_path=config_provider("pudl_path"),
+        renewable_weather_year=config_provider("renewable_weather_years"),
     input:
-        pudl=DATA + "pudl/pudl.sqlite",
         wecc_ads="repo_data/WECC_ADS_public",
         eia_ads_generator_mapping="repo_data/WECC_ADS_public/eia_ads_generator_mapping_updated.csv",
         fuel_costs="repo_data/plants/fuelCost22.csv",

--- a/workflow/rules/retrieve.smk
+++ b/workflow/rules/retrieve.smk
@@ -235,7 +235,6 @@ rule retrieve_caiso_data:
 
 rule retrieve_pudl:
     output:
-        pudl=DATA + "pudl/pudl.sqlite",
         pudl_ferc714=DATA + "pudl/out_ferc714__hourly_estimated_state_demand.parquet",
         census=DATA + "pudl/censusdp1tract.sqlite",
     log:

--- a/workflow/scripts/build_fuel_prices.py
+++ b/workflow/scripts/build_fuel_prices.py
@@ -143,7 +143,8 @@ def get_caiso_ng_power_prices(
 ###
 def build_pudl_fuel_costs(snapshots: pd.DatetimeIndex, start_date: str, end_date: str):
     """Build fuel costs based on PUDL EIA 923 Fuel Receipts data."""
-    _, fuel_cost_temporal = load_pudl_data(snakemake.input.pudl, start_date, end_date)
+    pudl_path = snakemake.params.pudl_path
+    _, fuel_cost_temporal = load_pudl_data(pudl_path, start_date, end_date)
     fuel_cost_temporal["interconnect"] = fuel_cost_temporal["nerc_region"].map(
         const.NERC_REGION_MAPPER,
     )

--- a/workflow/scripts/retrieve_pudl.py
+++ b/workflow/scripts/retrieve_pudl.py
@@ -15,10 +15,6 @@ if __name__ == "__main__":
     else:
         rootpath = "."
 
-    # Recommended to use the stable version of PUDL documented here:
-    # https://catalystcoop-pudl.readthedocs.io/en/latest/data_access.html#stable-builds
-    url_pudl = "https://zenodo.org/records/13346011/files/pudl.sqlite.zip?download=1"
-
     url_census = "https://zenodo.org/records/13346011/files/censusdp1tract.sqlite.zip?download=1"
     save_pudl = snakemake.output.pudl
     save_census = snakemake.output.census
@@ -27,11 +23,6 @@ if __name__ == "__main__":
         progress_retrieve(url_census, save_census + ".zip")
         with zipfile.ZipFile(save_census + ".zip", "r") as zip_ref:
             zip_ref.extractall(Path(save_census).parent)
-
-    if not Path(save_pudl).exists():
-        progress_retrieve(url_pudl, save_pudl + ".zip")
-        with zipfile.ZipFile(save_pudl + ".zip", "r") as zip_ref:
-            zip_ref.extractall(Path(save_pudl).parent)
 
     # Get PUDL FERC Form 714 Parquet
     parquet = "https://zenodo.org/records/11292273/files/out_ferc714__hourly_estimated_state_demand.parquet?download=1"


### PR DESCRIPTION
Closes #564 , #469 

## Changes proposed in this Pull Request
- Changes build_powerplants, build_fuel_prices, and build_cost_data to directly query the S3 hosted PUDL parquet files rather than downloading the entire pull.sqlite file from zenodo.
- Adds a new field in the `config.common.yaml` which tags the PUDL version to be used for all references to PUDL data.
- Removed hardcoded heat-rate/ static fuel cost data being pulled from 2019, now pulls from `renewable_weather_year` param. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [na] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [na ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
