### PR TITLE
Update PUDL path for sector studies

### DIFF
--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -303,9 +303,9 @@ def demand_scaling_data(wildcards):
         ].capitalize()
         return DATA + f"nrel_efs/EFSLoadProfile_{efs_case}_{efs_speed}.csv"
     elif profile == "eia":
-        return config_provider("pudl_path")
+        return []
     elif profile == "ferc":
-        return config_provider("pudl_path")
+        return []
     else:
         return ""
 
@@ -345,6 +345,7 @@ rule build_sector_demand:
         profile_year=pd.to_datetime(config["snapshots"]["start"]).year,
         eia_api=config_provider("api", "eia"),
         snapshots=config_provider("snapshots"),
+        pudl_path=config_provider("pudl_path"),
     input:
         network=RESOURCES + "{interconnect}/elec_base_network.nc",
         demand_files=demand_raw_data,


### PR DESCRIPTION
## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

As PUDL is no longer tracked through snakemake (ie. its a cofig path), the input function for the demand scaling file failed as `config_provider("pudl_path")` is not a `str` or `list[str]`

Updated to return empty lists, as we hack in the file paths already (in the `*.py` file) for the demand scaling! 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
