### PR TITLE
Refactors OSW Implementation

### DIFF
--- a/docs/source/config-spatial.md
+++ b/docs/source/config-spatial.md
@@ -31,7 +31,7 @@ scenario:
    simpl: [100]
 ```
 
-This setup results in a model with 10 transmission nodes and 100 distinct resource zones, allowing for more granular modeling of renewable resource distribution while keeping the transmission network simplified.
+This setup, using an `m` after the `clusters` wildcard, results in a model with 10 transmission nodes and 100 distinct renewable resource zones, allowing for more granular modeling of renewable resource distribution while keeping the transmission network simplified. If you use a `c` after the `clusters` wildcard, all conventional resources from the `simpl` step will not be clustered. If you input an `a` after the `clusters` wildcard, all resources will not be clustered beyond the `simpl` level.
 
 ## Configuring Transmission Resolution
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -70,7 +70,7 @@ localrules:
 wildcard_constraints:
     interconnect="usa|texas|western|eastern",
     simpl="[a-zA-Z0-9]*|all",
-    clusters="[0-9]+m?+c?|all",
+    clusters="[0-9]+m?+a?+c?|all",
     ll="(v|c)([0-9\.]+|opt|all)|all",
     opts="[-+a-zA-Z0-9\.]*",
     sector="([EG]-)*[EG]",

--- a/workflow/repo_data/config/config.common.yaml
+++ b/workflow/repo_data/config/config.common.yaml
@@ -140,5 +140,4 @@ offshore_shape:
   use: eez #options are ca_osw, eez
 
 offshore_network:
-  enable: true # set to true to enable offshore network
   bus_spacing: 25000 # km

--- a/workflow/scripts/build_base_network.py
+++ b/workflow/scripts/build_base_network.py
@@ -231,7 +231,15 @@ def build_offshore_buses(
     offshore_shapes: gpd.GeoDataFrame,
     offshore_spacing: int,
 ) -> pd.DataFrame:
-    """Build dataframe of offshore buses by creating evenly spaced grid cells inside of the offshore shapes."""
+    """
+    Build dataframe of offshore buses by creating evenly spaced grid cells inside of the offshore shapes.
+
+    Args:
+        offshore_shapes: gpd.GeoDataFrame
+            Offshore shapes to create grid cells inside of.
+        offshore_spacing: int
+            Spacing between grid cells in meters.
+    """
     offshore_buses = pd.DataFrame()
     offshore_shapes = offshore_shapes.to_crs("EPSG:5070")
     for shape in offshore_shapes.geometry:
@@ -247,13 +255,13 @@ def build_offshore_buses(
     offshore_buses = offshore_buses.to_crs("EPSG:4326")
     offshore_buses.lat = offshore_buses.geometry.y
     offshore_buses.lon = offshore_buses.geometry.x
-    offshore_buses["sub_id"] = np.arange(50000, 50000 + len(offshore_buses))
+    offshore_buses["sub_id"] = np.arange(50000, 50000 + len(offshore_buses))  # replace with onshore sub_ids
     offshore_buses.index = np.arange(3008161, 3008161 + len(offshore_buses))
     return offshore_buses
 
 
 def add_offshore_buses(n: pypsa.Network, offshore_buses: pd.DataFrame) -> pypsa.Network:
-    """Add offshore buses to network."""
+    """Add offshore buses to network and assigns it a POI."""
     n.madd(
         "Bus",
         offshore_buses.index,
@@ -265,11 +273,23 @@ def add_offshore_buses(n: pypsa.Network, offshore_buses: pd.DataFrame) -> pypsa.
         interconnect="Offshore",
         x=offshore_buses.lon,
         y=offshore_buses.lat,
-        sub_id=offshore_buses.sub_id.astype(int),
         substation_off=True,
         poi_sub=False,
         poi_bus=False,
     )
+
+    # assigns offshore buses to an onshore POI as sub_id
+    poi_buses = n.buses.loc[n.buses.poi_sub]  # identify the buses at the POI
+    eligible_poi_buses = poi_buses.loc[poi_buses.groupby("sub_id")["v_nom"].idxmax()]
+    offshore_buses_matched = match_missing_buses(eligible_poi_buses, n.buses.loc[n.buses.substation_off])
+
+    # Reassign offshore buses region attributes from their POI bus assignments
+    region_attrs = ["sub_id", "balancing_area", "state", "country", "interconnect", "reeds_zone", "reeds_ba", "county"]
+    for attr in region_attrs:
+        n.buses.loc[offshore_buses_matched.index, attr] = n.buses.loc[
+            offshore_buses_matched.bus_assignment,
+            attr,
+        ].values
     return n
 
 
@@ -317,85 +337,6 @@ def match_missing_buses(buses_to_match_to, missing_buses):
     return missing_buses
 
 
-def build_offshore_transmission_configuration(n: pypsa.Network) -> pypsa.Network:
-    """Builds offshore transmission configurations connecting offshore buses to the POIs onshore."""
-    poi_buses = n.buses.loc[n.buses.poi_sub]  # identify the buses at the POI
-    highest_voltage_buses = poi_buses.loc[poi_buses.groupby("sub_id")["v_nom"].idxmax()]
-    offshore_buses = match_missing_buses(
-        highest_voltage_buses,
-        n.buses.loc[n.buses.substation_off],
-    )  # match offshore buses to POI
-
-    osw_offsub_bus_ids = n.buses.loc[n.buses.substation_off].index
-
-    line_lengths = haversine_np(
-        n.buses.loc[offshore_buses.bus_assignment].x.values,
-        n.buses.loc[offshore_buses.bus_assignment].y.values,
-        offshore_buses.x.values,
-        offshore_buses.y.values,
-    )
-    # Reassigns Offshore buses region identifies to the POI bus regions
-    n.buses.loc[offshore_buses.index, "balancing_area"] = n.buses.loc[
-        offshore_buses.bus_assignment
-    ].balancing_area.values
-    n.buses.loc[offshore_buses.index, "state"] = n.buses.loc[offshore_buses.bus_assignment].state.values
-    n.buses.loc[offshore_buses.index, "country"] = n.buses.loc[offshore_buses.bus_assignment].country.values
-    n.buses.loc[offshore_buses.index, "interconnect"] = n.buses.loc[offshore_buses.bus_assignment].interconnect.values
-    n.buses.loc[offshore_buses.index, "reeds_zone"] = n.buses.loc[offshore_buses.bus_assignment].reeds_zone.values
-    n.buses.loc[offshore_buses.index, "reeds_ba"] = n.buses.loc[offshore_buses.bus_assignment].reeds_ba.values
-    n.buses.loc[offshore_buses.index, "county"] = n.buses.loc[offshore_buses.bus_assignment].county.values
-
-    # add onshore poi buses @230kV
-    n.madd(
-        "Bus",
-        "OSW_POI_" + osw_offsub_bus_ids,  # name poi bus after offshore substation
-        v_nom=230,
-        sub_id=offshore_buses.sub_id.values,
-        balancing_area=n.buses.loc[offshore_buses.bus_assignment].balancing_area.values,
-        state=n.buses.loc[offshore_buses.bus_assignment].state.values,
-        country="US",
-        interconnect=n.buses.loc[offshore_buses.bus_assignment].interconnect.values,
-        x=n.buses.loc[offshore_buses.bus_assignment].x.values,
-        y=n.buses.loc[offshore_buses.bus_assignment].y.values,
-        poi_bus=True,
-        poi_sub=True,
-        substation_off=False,
-    )
-
-    # add offshore wind export cables
-    logger.info("Adding offshore wind export lines to the network.")
-    n.madd(
-        "Line",
-        "OSW_export_" + osw_offsub_bus_ids,  # name line after offshore substation
-        v_nom=230,
-        bus0=osw_offsub_bus_ids.values,
-        bus1="OSW_POI_" + osw_offsub_bus_ids.values,
-        length=line_lengths,
-        type="temp",
-        carrier="AC",
-        x=0.1,
-        r=0.1,
-        s_nom=0.01,
-        underwater_fraction=0.0,  # temporarily setting to investigate clustering underwater issues later
-        interconnect=n.buses.loc[offshore_buses.bus_assignment].interconnect.values,
-    )
-
-    # add offshore transmission transformers
-    n.madd(
-        "Transformer",
-        "OSW_poi_stepup_" + osw_offsub_bus_ids,  # name transformer after offshore substation
-        bus0="OSW_POI_" + osw_offsub_bus_ids,
-        bus1=offshore_buses.bus_assignment.astype(str).values,
-        s_nom=0.01,
-        type="temp",
-        carrier="AC",
-        v_nom=230,
-        x=0.1,
-        r=0.1,
-    )
-    return n
-
-
 def remove_breakthrough_offshore(n: pypsa.Network) -> pypsa.Network:
     """
     Remove Offshore buses, Branches, Transformers, and Generators from the
@@ -439,48 +380,29 @@ def assign_missing_state_regions(gdf_bus: gpd.GeoDataFrame):
     return gdf_bus
 
 
-def assign_missing_states_countries(n: pypsa.Network):
-    """
-    Assign buses missing state and countries to their nearest neighbor bus
-    value.
-    """
-    buses = n.buses.copy()
-    missing = buses.loc[
-        (
-            buses.state.isna()
-            | buses.country.isna()
-            | buses.balancing_area.isna()
-            | buses.reeds_zone.isna()
-            | buses.reeds_ba.isna()
-            | buses.county.isna()
-        )
-    ]
-    buses = buses.loc[
-        (
-            ~buses.state.isna()
-            & ~buses.country.isna()
-            & ~buses.balancing_area.isna()
-            & ~buses.reeds_zone.isna()
-            & ~buses.reeds_ba.isna()
-            & ~buses.county.isna()
-        )
-    ]
-    buses = buses.loc[~buses.state.isin(["Offshore"])]
-    missing = match_missing_buses(buses, missing)
-    missing.balancing_area = buses.loc[missing.bus_assignment].balancing_area.values
-    missing.state = buses.loc[missing.bus_assignment].state.values
-    missing.country = buses.loc[missing.bus_assignment].country.values
-    missing.reeds_zone = buses.loc[missing.bus_assignment].reeds_zone.values
-    missing.reeds_ba = buses.loc[missing.bus_assignment].reeds_ba.values
-    missing.county = buses.loc[missing.bus_assignment].county.values
+def assign_missing_regions(n: pypsa.Network):
+    """Assign buses missing state and countries to their nearest neighbor bus value."""
+    # Define the region attributes to check and assign
+    region_attrs = ["balancing_area", "state", "country", "reeds_zone", "reeds_ba", "county", "interconnect"]
 
-    n.buses.loc[missing.index, "balancing_area"] = missing.balancing_area
-    n.buses.loc[missing.index, "state"] = missing.state
-    n.buses.loc[missing.index, "country"] = missing.country
-    n.buses.loc[missing.index, "reeds_zone"] = missing.reeds_zone
-    n.buses.loc[missing.index, "reeds_ba"] = missing.reeds_ba
-    n.buses.loc[missing.index, "county"] = missing.county
-    n.buses.loc[missing.index, "interconnect"] = missing.interconnect
+    # Identify buses with any missing region attributes
+    buses = n.buses.copy()
+    missing = buses.loc[buses[region_attrs].isna().any(axis=1)]
+
+    if missing.empty:
+        return
+
+    # Get reference buses with complete data
+    reference_buses = buses.loc[~buses[region_attrs].isna().any(axis=1)]
+    reference_buses = reference_buses.loc[~reference_buses.state.isin(["Offshore"])]
+
+    # Match missing buses to their nearest neighbors
+    missing = match_missing_buses(reference_buses, missing)
+
+    # Assign region attributes from matched buses to missing buses
+    for attr in region_attrs:
+        if attr in n.buses.columns:  # Only assign if column exists
+            n.buses.loc[missing.index, attr] = reference_buses.loc[missing.bus_assignment, attr].values
 
 
 def assign_reeds_memberships(n: pypsa.Network, fn_reeds_memberships: str):
@@ -511,14 +433,6 @@ def assign_reeds_memberships(n: pypsa.Network, fn_reeds_memberships: str):
     n.buses["trans_grp"] = n.buses.groupby("county")["trans_grp"].transform(
         lambda x: x.mode()[0],
     )
-
-    # # Assert that each county must have the same reeds_ba, reeds_zone, reeds_state, nerc_reg, and trans_reg
-    # assert n.buses.groupby("county")["reeds_ba"].nunique().eq(1).all()
-    # assert n.buses.groupby("county")["reeds_zone"].nunique().eq(1).all()
-    # assert n.buses.groupby("county")["reeds_state"].nunique().eq(1).all()
-    # assert n.buses.groupby("county")["nerc_reg"].nunique().eq(1).all()
-    # assert n.buses.groupby("county")["trans_reg"].nunique().eq(1).all()
-    # assert n.buses.groupby("county")["trans_grp"].nunique().eq(1).all()
 
 
 def modify_breakthrough_substations(buslocs: pd.DataFrame):
@@ -620,21 +534,20 @@ def main(snakemake):
     if interconnect == "Texas" or interconnect == "usa":
         n = assign_texas_poi(n)
     n = remove_breakthrough_offshore(n)
+    assign_missing_regions(n)
 
-    # build new offshore network configuration
-    if snakemake.params.build_offshore_network["enable"]:
-        offshore_buses = build_offshore_buses(
-            offshore_shapes,
-            snakemake.params.build_offshore_network["bus_spacing"],
-        )
-        n = add_offshore_buses(n, offshore_buses)
-        n = build_offshore_transmission_configuration(n)
+    # build offshore network configuration
+    offshore_buses = build_offshore_buses(
+        offshore_shapes,
+        snakemake.params.build_offshore_network["bus_spacing"],
+    )
+    n = add_offshore_buses(n, offshore_buses)
 
     # Assign Lines Types and Missing Region Memberships
     add_custom_line_type(n)
     assign_line_types(n)
     assign_line_length(n)
-    assign_missing_states_countries(n)
+    assign_missing_regions(n)
     assign_reeds_memberships(n, snakemake.input.reeds_memberships)
 
     p_max_pu = 1

--- a/workflow/scripts/build_bus_regions.py
+++ b/workflow/scripts/build_bus_regions.py
@@ -1,27 +1,5 @@
 # By PyPSA-USA Authors
-"""
-**Description**.
-
-Creates Voronoi shapes for each bus representing both onshore and offshore regions.
-
-**Relevant Settings**
-
-.. code:: yaml
-
-    interconnect:
-    topological_boundaries:
-
-**Inputs**
-
-- ``resources/country_shapes.geojson``: confer :ref:`shapes`
-- ``resources/offshore_shapes.geojson``: confer :ref:`shapes`
-- ``networks/base.nc``: confer :ref:`base`
-
-**Outputs**
-
-- ``resources/regions_onshore.geojson``
-- ``resources/regions_offshore.geojson``
-"""
+"""Creates Voronoi shapes for each bus representing both onshore and offshore regions."""
 
 import logging
 
@@ -133,7 +111,6 @@ def main(snakemake):
         right_on=n.buses.index,
     ).set_index("sub_id")
     bus2sub_onshore = bus2sub[bus2sub.Bus.isin(onshore_buses.index)]
-    bus2sub_offshore = bus2sub[~bus2sub.Bus.isin(onshore_buses.index)]
 
     logger.info("Building Onshore Regions")
     onshore_regions = []
@@ -177,10 +154,10 @@ def main(snakemake):
     buffered = combined_onshore.buffer(0.9)
     for i in range(len(offshore_shapes)):
         offshore_shape = offshore_shapes.iloc[i]
-        # Trip shape to be within certain distance from onshore_regions
+        # Trim shape to be within certain distance from onshore_regions
         offshore_shape = offshore_shape.intersection(buffered)
         shape_name = offshore_shapes.index[i]
-        offshore_buses = bus2sub_offshore[["x", "y"]]
+        offshore_buses = bus2sub_onshore[["x", "y"]]
         if offshore_buses.empty:
             continue
         offshore_regions_c = gpd.GeoDataFrame(


### PR DESCRIPTION
## Changes proposed in this Pull Request
I simplify the OSW transmission configuration and clustering set-up to ensure that at high resolutions, there aren't OSW substations which would double-count OSW transmission interconnection costs (since these costs are included from ATB).

The new behavior creates non-connected OSW buses which are assigned onshore POI substations. In the simplify_network `aggregate_to_substations` function, the OSW busses and thus generators are brought onshore. This assumes OSW transmission costs are baked into the OSW generator expansion cost.

I also add a new clustering configuration `a` which disables all clustering of generators beyond which is done in the `simpl` case.

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
