### PR TITLE
Conditional for Sector multi_period_investment

### DIFF
--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -1691,7 +1691,7 @@ def solve_network(n, config, solving, opts="", **kwargs):
     set_of_options = solving["solver"]["options"]
     cf_solving = solving["options"]
 
-    if len(n.investment_periods) > 1:
+    if "sector" not in opts:
         kwargs["multi_investment_periods"] = config["foresight"] == "perfect"
 
     kwargs["solver_options"] = solving["solver_options"][set_of_options] if set_of_options else {}


### PR DESCRIPTION
Hotfix for PR #581 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

As per PR #581, this causes sector to crash, but without it...
> pypsa doesn't properly account for the build_year and lifetime of assets. When you leave the flag off, it ignores those fields, which was leading to single horizon problems being improperly built.

This PR adds it in for electrical, but not for sectors. This is a temporary fix. 

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
