### PR TITLE
Downstream Methane Leaks

### DIFF
--- a/docs/source/configtables/sector_natural_gas.csv
+++ b/docs/source/configtables/sector_natural_gas.csv
@@ -10,5 +10,6 @@ natural_gas,,,Options when implementing natural gas networks
 -- standing_loss,per_unit,"float {0 <=, >= 1}","Leakage rate from pipelines. These leaks do NOT account towards emissions, just enforces gas production to replinish losses with cyclic constraints. "
 ,,,
 methane,,,Options of methane emission accounting attached to natural gas networks
--- leakage_rate,per_unit,"float {0 <=, >= 1}",Total leakage rate of natural gas in the system (upstream and downstream). Applied to gas processing facilities.
+-- upstream_leakage_rate,per_unit,"float {0 <=, >= 1}",Upstream per_unit leakage rate of natural gas. Applied to gas processing facilities.
+-- downstream_leakage_rate,per_unit,"float {0 <=, >= 1}",Downstream per_unit leakage rate of natural gas. Applied to all end-use technologies that use natural gas.
 -- gwp,--,float,Global warming potential of methane. GWP of 1 represents same carbon intensity as burned natural gas.

--- a/docs/source/data-naturalgas.md
+++ b/docs/source/data-naturalgas.md
@@ -86,12 +86,12 @@ PyPSA-USA does not currently support natural gas pipeline expansion and retrofit
 
 ### Methane Tracking
 
-Leaks in the natural gas system are often categorized into upstream and downstream leaks. Upstream leaks inclde leaks from production and processing. Downstream leaks include leaks from transportation, falaring, and incomplete fuel combustion. PyPSA-USA groups upstream and downstream leaks together and applies a leakage rate as a percentage of natural gas injected into the system. Moreover, a global warming potential is applied to the leaked gas the represent the intensity of methane compared to carbon dioxide over different time-frames. The follow [figure](methane-tracking) graphically shows how methane is accounted in PyPSA-USA.
+Leaks in the natural gas system are often categorized into upstream and downstream leaks. Upstream leaks inclde leaks from production and processing. Downstream leaks include leaks from transportation, falaring, and incomplete fuel combustion. PyPSA-USA allows users to specify both upstream and downstream leakage rates as a percentage of natural gas usage. Moreover, a global warming potential is applied to the leaked gas the represent the intensity of methane compared to carbon dioxide over different time-frames. The follow [figure](methane-tracking) graphically shows how methane is accounted in PyPSA-USA.
 
 :::{figure-md} methane-tracking
 <img src="./_static/natural_gas/methane.png" width="600px">
 
-Methane Tracking in PyPSA-USA
+Upstream Methane Tracking in PyPSA-USA
 :::
 
 ## Data Sources

--- a/workflow/repo_data/config/config.sector.yaml
+++ b/workflow/repo_data/config/config.sector.yaml
@@ -14,7 +14,8 @@ sector:
     cyclic_storage: true
     standing_loss: 0
   methane:
-    leakage_rate: 0.02 # per unit 
+    upstream_leakage_rate: 0.02 # per unit 
+    downstream_leakage_rate: 0.02 # per unit 
     gwp: 0 
   # docs-heating
   heating:

--- a/workflow/scripts/add_sectors.py
+++ b/workflow/scripts/add_sectors.py
@@ -587,13 +587,6 @@ if __name__ == "__main__":
         options=ng_options,
     )
 
-    # add methane tracking - if leakage rate is included
-    # this must happen after natural gas system is built
-    methane_options = snakemake.params.sector["methane"]
-    leakage_rate = methane_options.get("leakage_rate", 0)
-    gwp = methane_options.get("gwp", 0)
-    build_ch4_tracking(n, gwp, leakage_rate)
-
     pop_layout_path = snakemake.input.clustered_pop_layout
     cop_ashp_path = snakemake.input.cop_air_total
     cop_gshp_path = snakemake.input.cop_soil_total
@@ -745,6 +738,14 @@ if __name__ == "__main__":
                 ratios=ratio,
                 costs=costs,
             )
+
+    # add methane tracking - if leakage rate is included
+    # this must happen after all technologies and nat gas is built
+    methane_options = snakemake.params.sector["methane"]
+    upstream_leakage_rate = methane_options.get("upstream_leakage_rate", 0)
+    downstream_leakage_rate = methane_options.get("downstream_leakage_rate", 0)
+    gwp = methane_options.get("gwp", 0)
+    build_ch4_tracking(n, gwp, upstream_leakage_rate, downstream_leakage_rate)
 
     # Needed as loads may be split off to urban/rural
     sanitize_carriers(n, snakemake.config)

--- a/workflow/scripts/build_emission_tracking.py
+++ b/workflow/scripts/build_emission_tracking.py
@@ -57,7 +57,7 @@ def build_ch4_tracking(
 
     # supress pypsa warnings
     n.links["bus3"] = n.links.bus3.fillna("")
-    n.links["efficiency3"] = n.links.efficiency3.fillna("")
+    n.links["efficiency3"] = n.links.efficiency3.fillna(0)
 
 
 def _add_co2_carrier(n, config: dict[Any]):

--- a/workflow/scripts/build_emission_tracking.py
+++ b/workflow/scripts/build_emission_tracking.py
@@ -33,8 +33,9 @@ def build_co2_tracking(
 def build_ch4_tracking(
     n: pypsa.Network,
     gwp: float,
-    leakage_rate: float,
-    config: dict[str, Any] | None = None,
+    upstream_leakage_rate: float,
+    downstream_leakage_rate: float,
+    plotting_config: dict[str, Any] | None = None,
 ) -> None:
     """
     Builds CH4 tracking.
@@ -43,15 +44,20 @@ def build_ch4_tracking(
     """
     states = [x for x in n.buses.STATE.dropna().unique() if x != np.nan]
 
-    if not config:
-        config = {}
+    if not plotting_config:
+        plotting_config = {}
 
     if "ch4" not in n.carriers:
-        _add_ch4_carrier(n, config)
+        _add_ch4_carrier(n, plotting_config)
 
     _build_ch4_bus(n, states)
     _build_ch4_store(n, states)
-    _build_ch4_links(n, states, gwp, leakage_rate)
+    _build_ch4_upstream(n, gwp, upstream_leakage_rate)
+    _build_ch4_downstream(n, gwp, downstream_leakage_rate)
+
+    # supress pypsa warnings
+    n.links["bus3"] = n.links.bus3.fillna("")
+    n.links["efficiency3"] = n.links.efficiency3.fillna("")
 
 
 def _add_co2_carrier(n, config: dict[Any]):
@@ -142,17 +148,41 @@ def _build_ch4_store(n: pypsa.Network, states: list[str]):
     )
 
 
-def _build_ch4_links(n, states: list[str], gwp: float, leakage_rate: float):
+def _build_ch4_upstream(n, gwp: float, leakage_rate: float):
     """Modifies existing gas production links."""
     # first extract out exising gas production links
-
-    gas_production = [f"{x} gas production" for x in states]
-    links = n.links[n.links.index.isin(gas_production)].index
+    links = n.links[n.links.carrier == "gas production"].index
 
     # calculate co2e value per unit injected to the ng system
     emissions = gwp * leakage_rate
 
     # append the connection to methane stores
 
-    n.links.loc[links, "bus2"] = n.links.loc[links,].bus1 + "-ch4"  # 'CA gas-ch4'
-    n.links.loc[links, "efficiency2"] = emissions
+    if "bus3" in n.links.columns:
+        assert all(n.links.loc[links].bus3.isna())
+    if "efficiency3" in n.links.columns:
+        assert all(n.links.loc[links].efficiency3.isna())
+
+    n.links.loc[links, "bus3"] = n.links.loc[links,].bus1 + "-ch4"  # 'CA gas-ch4'
+    n.links.loc[links, "efficiency3"] = emissions
+
+
+def _build_ch4_downstream(n, gwp: float, leakage_rate: float):
+    """Modifies existing gas consuming links."""
+    # want all gas links that originate at the state and are not trade or storage related
+
+    gas_buses = n.buses[n.buses.carrier == "gas"]
+    gas_users = n.links[(n.links.bus0.isin(gas_buses.index)) & ~(n.links.carrier.isin(["gas storage", "gas trade"]))]
+
+    links = gas_users.index
+
+    # calculate co2e value per unit injected to the ng system
+    emissions = gwp * leakage_rate
+
+    # append the connection to methane stores
+
+    assert all(n.links.loc[links].bus3.isna())
+    assert all(n.links.loc[links].efficiency3.isna())
+
+    n.links.loc[links, "bus3"] = n.links.loc[links,].bus0 + "-ch4"  # 'CA gas-ch4'
+    n.links.loc[links, "efficiency3"] = emissions


### PR DESCRIPTION
Closes #588 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

This PR adds downstream emission leaks. Upstream leakage is applied at the `gas production` store. Downstream leakage applies to all links that originate at the state level gas tracking bus. All CH4 tracking has been moved the `bus3`/`efficiency3` attributes. CO2 tracking remains on the `bus2`/`efficiency2` attributes. 



## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
