### PR TITLE
GlobalConstraint Dual Values Hotfix

### DIFF
--- a/workflow/scripts/opts/sector.py
+++ b/workflow/scripts/opts/sector.py
@@ -109,20 +109,26 @@ def add_sector_co2_constraints(n, config):
                 & ((n.stores.index.str.endswith(f"{sector}-co2")) | (n.stores.index.str.endswith(f"{sector}-ch4")))
             ].index
             name = f"GlobalConstraint-co2_limit-{year}-{state}-{sector}"
-            log_statement = f"Adding {state} {sector} co2 Limit in {year} of"
+            if stores.empty:
+                log_statement = f"No co2 stores found for {state} {year} {sector}"
+            else:
+                log_statement = f"Adding {state} {sector} co2 Limit in {year} of"
         else:
             stores = n.stores[
                 (n.stores.index.str.startswith(state))
                 & ((n.stores.index.str.endswith("-co2")) | (n.stores.index.str.endswith("-ch4")))
             ].index
             name = f"GlobalConstraint-co2_limit-{year}-{state}"
-            log_statement = f"Adding {state} co2 Limit in {year} of"
+            if stores.empty:
+                log_statement = f"No co2 stores found for {state} {year}"
+            else:
+                log_statement = f"Adding {state} co2 Limit in {year} of"
 
         if stores.empty:
-            logger.warning(f"No co2 stores found for {state} {year} {sector}")
+            logger.warning(log_statement)
             return
 
-        lhs = n.model["Store-e"].loc[:, stores].sum(dim="Store")
+        lhs = n.model["Store-e"].loc[:, stores].sel(snapshot=n.snapshots[-1]).sum(dim="Store")
         rhs = value  # value in T CO2
 
         n.model.add_constraints(lhs <= rhs, name=name)
@@ -146,7 +152,7 @@ def add_sector_co2_constraints(n, config):
             logger.warning(f"No co2 stores found for USA {year} {sector}")
             return
 
-        lhs = n.model["Store-e"].loc[:, stores].sum(dim="Store")
+        lhs = n.model["Store-e"].loc[:, stores].sel(snapshot=n.snapshots[-1]).sum(dim="Store")
         rhs = value  # value in T CO2
 
         n.model.add_constraints(lhs <= rhs, name=name)

--- a/workflow/scripts/opts/sector.py
+++ b/workflow/scripts/opts/sector.py
@@ -118,6 +118,10 @@ def add_sector_co2_constraints(n, config):
             name = f"GlobalConstraint-co2_limit-{year}-{state}"
             log_statement = f"Adding {state} co2 Limit in {year} of"
 
+        if stores.empty:
+            logger.warning(f"No co2 stores found for {state} {year} {sector}")
+            return
+
         lhs = n.model["Store-e"].loc[:, stores].sum(dim="Store")
         rhs = value  # value in T CO2
 
@@ -137,6 +141,10 @@ def add_sector_co2_constraints(n, config):
             stores = n.stores[((n.stores.index.str.endswith("-co2")) | (n.stores.index.str.endswith("-ch4")))].index
             name = f"co2_limit-{year}"
             log_statement = f"Adding national co2 Limit in {year} of"
+
+        if stores.empty:
+            logger.warning(f"No co2 stores found for USA {year} {sector}")
+            return
 
         lhs = n.model["Store-e"].loc[:, stores].sum(dim="Store")
         rhs = value  # value in T CO2

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -27,6 +27,7 @@ import copy
 import logging
 
 import numpy as np
+import pandas as pd
 import pypsa
 import yaml
 from _helpers import (
@@ -347,6 +348,26 @@ def solve_network(n, config, solving, opts="", **kwargs):
     return n
 
 
+def _assign_duals_globalconstraint_fix(n: pypsa.Network):
+    """
+    Assigns duals to global constraints.
+
+    This is a hacky fix where for a single pnl global constraint, names for duals are not
+    written correctly for io operation. This is not an issue if multiple pnl global
+    constraints are present.
+
+    See the following issues for more details:
+    - https://github.com/PyPSA/PyPSA/issues/850
+    - https://github.com/PyPSA/pypsa-usa/issues/604
+    """
+    if not n.pnl("GlobalConstraint"):
+        return
+    for constraint_name, constraint_duals in n.pnl("GlobalConstraint").items():
+        pnl = constraint_duals
+        if isinstance(pnl, pd.Series):
+            n.pnl("GlobalConstraint")[constraint_name] = pnl.to_frame(name="mu")
+
+
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
@@ -402,6 +423,7 @@ if __name__ == "__main__":
         store_ERM_duals(n)
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    _assign_duals_globalconstraint_fix(n)
     n.export_to_netcdf(snakemake.output[0])
     with open(snakemake.output.config, "w") as file:
         yaml.dump(
@@ -411,3 +433,4 @@ if __name__ == "__main__":
             allow_unicode=True,
             sort_keys=False,
         )
+    print("done")


### PR DESCRIPTION
Closes #604

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

There seems to be an issue extracting dual values if we declare a dynamic/pnl GlobalConstraint. I'm not super sure why this isn't allowed by default, but this hotfix should correct it. This is tangentially related to [this issue](https://github.com/PyPSA/PyPSA/issues/850) on the main pypsa repo. 

In this hotfix, I just changed the co2 constraint to look at the last timeslice to ensure it meets limits, instead of every timestep. Therefore, it isnt caught up in the pnl io operations I guess. Alternatively, this code worked if we did not want to change the co2 constraint, however, its a little clunky. 

```
def _assign_duals_globalconstraint_fix(n: pypsa.Network):
    """
    Assigns duals to global constraints.

    This is a hacky fix where for a single pnl global constraint, names for duals are not
    written correctly for io operation. This is not an issue if multiple pnl global
    constraints are present.

    See the following issues for more details:
    - https://github.com/PyPSA/PyPSA/issues/850
    - https://github.com/PyPSA/pypsa-usa/issues/604
    """
    if not n.pnl("GlobalConstraint"):
        return
    for constraint_name, constraint_duals in n.pnl("GlobalConstraint").items():
        pnl = constraint_duals
        if isinstance(pnl, pd.Series):
            n.pnl("GlobalConstraint")[constraint_name] = pnl.to_frame(name="mu")
``` 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
