### PR TITLE
Enable REC Trading for RPS Opt

### DIFF
--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -557,7 +557,7 @@ rule build_powerplants:
         cems="repo_data/plants/cems_heat_rates.xlsx",
         epa_crosswalk="repo_data/plants/epa_eia_crosswalk.csv",
     output:
-        powerplants=RESOURCES + "powerplants.csv",
+        powerplants="resources/powerplants.csv",
     log:
         "logs/build_powerplants.log",
     resources:
@@ -603,7 +603,7 @@ rule add_electricity:
         regions_offshore=RESOURCES
         + "{interconnect}/Geospatial/regions_offshore.geojson",
         reeds_shapes=RESOURCES + "{interconnect}/Geospatial/reeds_shapes.geojson",
-        powerplants=RESOURCES + "powerplants.csv",
+        powerplants="resources/powerplants.csv",
         plants_breakthrough=DATA + "breakthrough_network/base_grid/plant.csv",
         hydro_breakthrough=DATA + "breakthrough_network/base_grid/hydro.csv",
         bus2sub=RESOURCES + "{interconnect}/bus2sub.csv",

--- a/workflow/scripts/build_base_network.py
+++ b/workflow/scripts/build_base_network.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pypsa
 from _helpers import configure_logging
 from build_shapes import load_na_shapes
+from constants import REC_TRADING_ZONE_MAPPER
 from shapely.geometry import Polygon
 from sklearn.neighbors import BallTree
 
@@ -550,6 +551,7 @@ def main(snakemake):
     assign_line_length(n)
     assign_missing_regions(n)
     assign_reeds_memberships(n, snakemake.input.reeds_memberships)
+    n.buses["rec_trading_zone"] = n.buses.reeds_state.map(REC_TRADING_ZONE_MAPPER).fillna(n.buses.reeds_state)
 
     p_max_pu = 1
     n.links["p_max_pu"] = p_max_pu

--- a/workflow/scripts/constants.py
+++ b/workflow/scripts/constants.py
@@ -575,6 +575,47 @@ REEDS_NERC_INTERCONNECT_MAPPER = {
     "ERCOT": "texas",
 }
 
+
+REC_TRADING_ZONE_MAPPER = {
+    "CA": "WREGIS",
+    "OR": "WREGIS",
+    "AZ": "WREGIS",
+    "WA": "WREGIS",
+    "NM": "WREGIS",
+    "UT": "WREGIS",
+    "CO": "WREGIS",
+    "NV": "WREGIS",
+    "ID": "WREGIS",
+    "WY": "WREGIS",
+    "MT": "WREGIS",
+    "ND": "MRETS",
+    "SD": "MRETS",
+    "MN": "MRETS",
+    "IA": "MRETS",
+    "WI": "MRETS",
+    "MI": "MIRECS",
+    "MO": "NAR",
+    "KS": "NAR",
+    "IL": "MRETS",
+    "IN": "MRETS",
+    "OH": "MRETS",
+    "KY": "PJM-GATS",
+    "VA": "PJM-GATS",
+    "WV": "PJM-GATS",
+    "MD": "PJM-GATS",
+    "DE": "PJM-GATS",
+    "NJ": "PJM-GATS",
+    "PA": "PJM-GATS",
+    "NY": "NYGATS",
+    "CT": "NEPOOL",
+    "RI": "NEPOOL",
+    "MA": "NEPOOL",
+    "NH": "NEPOOL",
+    "ME": "NEPOOL",
+    "VT": "NEPOOL",
+    "NC": "NC-RETS",
+    "TX": "ERCOT",
+}
 ################################
 # Constants for Breakthrough mapping
 ################################

--- a/workflow/scripts/opts/_helpers.py
+++ b/workflow/scripts/opts/_helpers.py
@@ -1,5 +1,6 @@
 import logging
 
+import numpy as np
 import pandas as pd
 import pypsa
 
@@ -88,3 +89,11 @@ def filter_components(
         ]
 
     return filtered
+
+
+def ceil_precision(a, precision=0):
+    return np.true_divide(np.ceil(a * 10**precision), 10**precision)
+
+
+def floor_precision(a, precision=0):
+    return np.true_divide(np.floor(a * 10**precision), 10**precision)

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -134,9 +134,7 @@ def extra_functionality(n, snapshots):
         "RPS": lambda: add_RPS_constraints(n, config, sector_enabled, global_snakemake)
         if n.generators.p_nom_extendable.any()
         else None,
-        "REM": lambda: add_regional_co2limit(n, config, global_snakemake)
-        if n.generators.p_nom_extendable.any()
-        else None,
+        "REM": lambda: add_regional_co2limit(n, config) if n.generators.p_nom_extendable.any() else None,
         "PRM": lambda: add_PRM_constraints(n, config, global_snakemake)
         if n.generators.p_nom_extendable.any()
         else None,


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Enables REC trading for RPS Opts according to Zones that roughly match the [epa attribute tracking regions](https://www.epa.gov/green-power-markets/energy-attribute-tracking-systems). All regions match with the exception of states split between PJM and MRETS. I will follow up with a PR that provides maps on each states eligible trading partners.
- Moves output of build_powerplants out of the RUN dependent resources subdirectory and into the base resources folder so that it doesn't get re-run between user runs. 
- Modifies TCT opt to use floating point precision rounding helper functions rather than the hackier plus epsilon

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
