### PR TITLE
PUDL Vers. Bump  v2025.05; Change to Query

### DIFF
--- a/workflow/repo_data/config/config.common.yaml
+++ b/workflow/repo_data/config/config.common.yaml
@@ -1,4 +1,4 @@
-pudl_path: s3://pudl.catalyst.coop/v2025.2.0
+pudl_path: s3://pudl.catalyst.coop/v2025.5.0
 
 # docs :
 renewable:

--- a/workflow/scripts/build_fuel_prices.py
+++ b/workflow/scripts/build_fuel_prices.py
@@ -31,7 +31,7 @@ from _helpers import configure_logging, get_snapshots, mock_snakemake
 from build_powerplants import (
     filter_outliers_iqr_grouped,
     filter_outliers_zscore,
-    load_pudl_data,
+    load_heat_rates_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -144,7 +144,7 @@ def get_caiso_ng_power_prices(
 def build_pudl_fuel_costs(snapshots: pd.DatetimeIndex, start_date: str, end_date: str):
     """Build fuel costs based on PUDL EIA 923 Fuel Receipts data."""
     pudl_path = snakemake.params.pudl_path
-    _, fuel_cost_temporal = load_pudl_data(pudl_path, start_date, end_date)
+    fuel_cost_temporal = load_heat_rates_data(pudl_path, start_date, end_date)
     fuel_cost_temporal["interconnect"] = fuel_cost_temporal["nerc_region"].map(
         const.NERC_REGION_MAPPER,
     )

--- a/workflow/scripts/build_powerplants.py
+++ b/workflow/scripts/build_powerplants.py
@@ -967,4 +967,10 @@ if __name__ == "__main__":
     plants = plants[~plants.index.isin(missing_locations.index)]
 
     logger.info(f"Exporting Powerplants, with {plants.shape[0]} entries.")
+
+    # Sort columns alphabetically for consistent diffing
+    plants = plants.reindex(sorted(plants.columns), axis=1)
+    # Sort rows by generator_name for consistent diffing
+    plants = plants.sort_values("generator_name")
+
     plants.to_csv(snakemake.output.powerplants, index=False)

--- a/workflow/scripts/simplify_network.py
+++ b/workflow/scripts/simplify_network.py
@@ -216,7 +216,7 @@ if __name__ == "__main__":
     n = pickle.load(open(snakemake.input.network, "rb"))
 
     n.generators = n.generators.drop(
-        columns=["ba_eia", "ba_ads"],
+        columns=["ba_eia"],
     )  # temp added these columns and need to drop for workflow
 
     n = convert_to_voltage_level(n, 230)


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Bumps to PUDL version v2025.05.00
- Changes Query to now include plants under construction and retired plants. Previously when running historical simulations, we had not included recently retired power plants... this had a strong impact by tossing out recent coal retirements. 
- Minor refactor of build_powerplants to remove unused data and other small changes. 
