### PR TITLE
Retain empty demand

### DIFF
--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -1630,7 +1630,6 @@ class WriteStrategy(ABC):
             dissag_load = load_per_bus.mul(laf.laf, axis=0).dropna()
             assert dissag_load.shape == load_per_bus.shape  # ensure no data is lost
             dissag_load = dissag_load.T  # set snapshot as index
-            dissag_load = dissag_load.loc[:, (dissag_load != 0).any(axis=0)]
             all_load.append(dissag_load)
 
         load = pd.concat(all_load, axis=1)
@@ -2300,16 +2299,21 @@ if __name__ == "__main__":
         #     end_use="transport",
         #     vehicle="rail-passenger",
         # )
-        # snakemake = mock_snakemake(
-        #     "build_transport_road_demand",
-        #     interconnect="western",
-        #     end_use="transport",
-        # )
         snakemake = mock_snakemake(
-            "build_sector_demand",
+            "build_transport_road_demand",
             interconnect="western",
-            end_use="residential",
+            end_use="transport",
         )
+        # snakemake = mock_snakemake(
+        #     "build_sector_demand",
+        #     interconnect="western",
+        #     end_use="residential",
+        # )
+        # snakemake = mock_snakemake(
+        #     "build_sector_demand",
+        #     interconnect="western",
+        #     end_use="residential",
+        # )
     configure_logging(snakemake)
 
     n = pypsa.Network(snakemake.input.network)


### PR DESCRIPTION
Closes #618 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

This PR updates the transport demand building to retain empty demand. This was originally added to speed up demand addition, by removing empty rows. The issue with that is if no demand exists (ie. 2030 efs reference case of heavy-duty electric vehicles), no demand nodes are built. Therefore, this solution takes the hit on efficiency (with retaining empty demand) but guarantees all buses are built.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
