### PR TITLE
Add `data_model` rule

### DIFF
--- a/docs/source/about-usage.md
+++ b/docs/source/about-usage.md
@@ -27,6 +27,22 @@ mamba activate pypsa-usa
 snakemake -j1 --configfile config/config.default.yaml
 ```
 
+### Generate Data Model
+
+To generate the data model only, specify the rule `data_model` in the `snakemake` call. The `data_model` rule generates the network file that is passed into the `solve_network` rule. This network will **not** include any additional policy constraints and only includes input data (ie. the network is not solved). The network is available in the `resources/` folder.
+
+UV:
+```console
+uv run snakemake data_model -j1 --configfile config/config.default.yaml --scheduler-ilp-solver GUROBI_CMD
+```
+
+mamba:
+```console
+mamba activate pypsa-usa
+snakemake data_model -j1 --configfile config/config.default.yaml
+```
+
+
 ## Running on HPC Cluster
 
 If you are running the workflow on an High-Performance Compute (HPC) cluster, you will first need to update the configuration settings in `config.cluster.yaml`. Update the account, partition, email, and chdir fields to match the information of your institutions cluster.

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -211,14 +211,6 @@ def sector_figures(wildcards):
                 figure=FIGURES_SECTOR_SANKEY,
             )
         )
-        # figs.append(
-        #     expand(
-        #         RESULTS
-        #         + "{interconnect}/figures/s{simpl}_c{clusters}/l{ll}_{opts}_{sector}/system/validate/{figure}.png",
-        #         **config["scenario"],
-        #         figure=FIGURES_SECTOR_VALIDATE,
-        #     )
-        # )
         return list(chain(*figs))
     return figs
 
@@ -241,6 +233,15 @@ rule all:
         sector_figures,
         validation_figures,
         #"repo_data/dag.jpg",
+
+
+rule data_model:
+    input:
+        expand(
+            RESOURCES
+            + "{interconnect}/elec_s{simpl}_c{clusters}_ec_l{ll}_{opts}_{sector}.nc",
+            **config["scenario"],
+        ),
 
 
 # Create DAG with-


### PR DESCRIPTION
## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

I had a request from a user to only generate the data model, without actually solving the network. This PR adds a `data_model` rule to do this. No logic is changed in this PR. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
