### PR TITLE
Endogenous Road Transport 

### DIFF
--- a/docs/source/configtables/sector_transport.csv
+++ b/docs/source/configtables/sector_transport.csv
@@ -2,8 +2,7 @@
 transport_sector ,,,Options when implementing the transport sector
 -- brownfield,--,"bool {true, false}",Include brownfield end-use capacity for all modelled modes of operation.
 -- dynamic_costs,--,"bool {true, false}",Apply sector specific time varrying gasoline costs
--- exogenous,--,"bool {true, false}",Apply exogenous electrification standards.
--- ev_policy,--,str,Path to exogenous electrificion standards configuration file.
+-- must_run_evs,--,"bool {true, false}",If EV capacity factors match the load profile
 -- modes,,,Modes of transportation to include. (Only True implemented)
 -- -- vehicle,,"bool {true, false}","Include light-duty, medium-duty, heavy-duty, and bus road transportation. "
 -- -- rail,,"bool {true, false}",Include passenger and freight rail

--- a/docs/source/data-transportation.md
+++ b/docs/source/data-transportation.md
@@ -61,29 +61,7 @@ Notably, travel indicators are in units of vehicle-miles travelled (or similar);
 
 ### Capacity Expansion
 
-Two capacity expansion options exist for road transportation in PyPSA-USA. Users can either set state-level electrification mandates, or users can allow the model to perfom investment decisions endogenously.
-
-```{note}
-Mode shifting studies are not currently supported (ie. Switching light-duty demand to bus demand)
-```
-
-#### Exogenous Investment
-
-Users can explicitly tell PyPSA-USA how much of the vehicle load by mode is met by electricity and petrol. This is useful in cicumstances where research questions involve evaluating specific vehicle mandates.
-
-When running in exogenous investment mode, the total demand by vehicle type is split into two categories; electricity and petrol. Electricity load follows the profiles described above. Petrol loads are flat and distributed evenly over the year. A schematic of the exogenous transport investment decisions is given in the figure below.
-
-:::{figure-md} exogenous-load
-<img src="./_static/transport/exogenous.png" width="800px">
-
-Schematic of how exogenous road transport investment is setup in PyPSA-USA
-:::
-
-#### Endogenous Investment
-
-Alternatively, users can allow PyPSA-USA to make road transport investment decisions. This is useful when research questions involve evaluating the impacts of one vehicle type against another.
-
-When running in endogenous investment mode, the total demand by vehicle type is grouped into a single load. Both electrical and petrol vehicle capacity can be invested in to meet the total load. A schematic of the endogenous transport investment decisions is given in the figure below.
+All road transportation investment decisions are endogenous in PyPSA-USA. The total demand by vehicle type is grouped into a single load. Both electrical and petrol vehicle capacity can be invested in to meet the total load. A schematic of the endogenous transport investment decisions is given in the figure below.
 
 :::{figure-md} endogenous-load
 <img src="./_static/transport/endogenous.png" width="800px">
@@ -91,9 +69,17 @@ When running in endogenous investment mode, the total demand by vehicle type is 
 Schematic of how endogenous road transport investment is setup in PyPSA-USA
 :::
 
+Often, endogenous investemnt decisions in the transportation sector will result in EVs depolyed at an unrealistic timelines. This is primarly due to their lower lifetime costs. To account for this, users can set state-level maximum electrification limits per vehicle class. The default values for electrification rates are taken from the NREL Electrifcation Futures Study.
+
+```{note}
+Mode shifting studies are not currently supported (ie. Switching light-duty demand to bus demand)
+```
+
+#### EV Operational Constraints
+
 A challenge with endogenous investment decisions is modifying the electrical load to account for a greater share of EVs in the system. Load is exogenous to the system, meaning it must be defined by the user. However, if more EVs are invested in, then the magnitude of the electrical load profile should grow. To account for this, two configuration options are exposed to the user.
 
-With endogenous road transport, users can set EVs to must-run. In this configuration, the total load per vehicle type profile is set to match the EV load profile. The EV links minimum and maximum operating limits are set to match the load profile. The petrol links are free to operate as little or as much as they like. This setup forces EVs to always be run, and petrol vehicles to fill in remaining load. A schematic of this is shown in the figure below.
+Users can set EVs to *must-run*. In this configuration, the total load per vehicle type profile is set to match the EV load profile. The EV links minimum and maximum operating limits are set to match the load profile. The petrol links are free to operate as little or as much as they like. This setup forces EVs to always be run, and petrol vehicles to fill in remaining load. A schematic of this is shown in the figure below.
 
 :::{figure-md} must-run-ev
 <img src="./_static/transport/must-run-ev.png" width="800px">
@@ -101,8 +87,7 @@ With endogenous road transport, users can set EVs to must-run. In this configura
 Schematic of *Must-Run EV* configuration for endogenous road transport investments
 :::
 
-Alternatively, with endogenous road transport users can set EVs and petrol vehicles to operate as little or as much as they like.
-In this configuration, the total load per vehicle type profile is set to match the EV load profile (same as must-run). The EV and petrol maximum generation matches that of the load profile, and both have a no lower generation requirement. In this setup, EVs and petrols are free to contribute as much or as little to the demand as they like; ie. petrol cars can act as a "peaking" resource. A schematic of this is shown in the figure below.
+Alternatively, users can set EVs and petrol vehicles to operate as little or as much as they like. In this configuration, the total load per vehicle type profile is set to match the EV load profile (same as must-run). The EV and petrol maximum generation matches that of the load profile, and both have a no lower generation requirement. In this setup, EVs and petrols are free to contribute as much or as little to the demand as they like; ie. petrol cars can act as a "peaking" resource. A schematic of this is shown in the figure below.
 
 :::{figure-md} vehicle-choice
 <img src="./_static/transport/vehicle-choice.png" width="800px">

--- a/workflow/repo_data/config/config.plotting.yaml
+++ b/workflow/repo_data/config/config.plotting.yaml
@@ -147,15 +147,19 @@ plotting:
     trn-lpg-veh-bus: "#2C2CD3"
 
     trn-rail: "#0a0100"
+    trn-rail-psg: "#0a0100"
+    trn-rail-ship: "#0a0100"
     trn-lpg-rail: "#0a0100"
     trn-lpg-rail-psg: "#9F9160"
     trn-lpg-rail-ship: "#606E9F"
 
     trn-air: "#0a0100"
+    trn-air-psg: "#0a0100"
     trn-lpg-air: "#0a0100"
     trn-lpg-air-psg: "#A45B75"
 
     trn-boat: "#0a0100"
+    trn-boat-ship: "#0a0100"
     trn-lpg-boat: "#0a0100"
     trn-lpg-boat-ship: "#5BA48A"
 
@@ -382,15 +386,19 @@ plotting:
     trn-lpg-veh-bus: "Gas Bus"
 
     trn-rail: "Rail"
+    trn-rail-psg: "Passenger Rail"
+    trn-rail-ship: "Shipping Rail"
     trn-lpg-rail: "Rail Oil"
-    trn-lpg-rail-psg: "Passenger Rail Gas"
-    trn-lpg-rail-ship: "Shipping Rail Gas"
+    trn-lpg-rail-psg: "Passenger Rail Oil"
+    trn-lpg-rail-ship: "Shipping Rail Oil"
 
     trn-air: "Airplane"
+    trn-air-psg: "Passenger Airplane"
     trn-lpg-air: "Airplane Gas"
     trn-lpg-air-psg: "Passenger Air Gas"
 
-    trn-boat: "Marine Shipping Gas"
+    trn-boat: "Marine Shipping"
+    trn-boat-ship: "Marine Shipping"
     trn-lpg-boat: "Domestic Marine Shipping Gas"
     trn-lpg-boat-ship: "Domestic Marine Shipping Gas"
 

--- a/workflow/repo_data/config/config.sector.yaml
+++ b/workflow/repo_data/config/config.sector.yaml
@@ -62,10 +62,8 @@ sector:
   transport_sector:
     brownfield: True # false to be implemented
     dynamic_costs: True # false to be implemented 
-    investment:
-      exogenous: False 
-      ev_policy: "config/policy_constraints/ev_policy.csv"
-      must_run_evs: True
+    ev_policy: "config/policy_constraints/ev_policy.csv"
+    must_run_evs: True
     modes: # false to be implemented 
       vehicle: true
       rail: true

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -435,7 +435,7 @@ rule build_transport_other_demand:
         demand_files=demand_raw_data,
         dissagregate_files=demand_dissagregate_data,
     output:
-        RESOURCES + "{interconnect}/demand/{end_use}_{vehicle}_lpg.pkl",
+        RESOURCES + "{interconnect}/demand/{end_use}_{vehicle}.pkl",
     log:
         LOGS + "{interconnect}/demand/{end_use}_{vehicle}_build_demand.log",
     benchmark:

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -335,9 +335,9 @@ rule build_electrical_demand:
         "../scripts/build_demand.py"
 
 
-rule build_sector_demand:
+rule build_service_demand:
     wildcard_constraints:
-        end_use="residential|commercial|industry",
+        end_use="residential|commercial",
     params:
         planning_horizons=config_provider("scenario", "planning_horizons"),
         profile_year=pd.to_datetime(config["snapshots"]["start"]).year,
@@ -350,13 +350,38 @@ rule build_sector_demand:
         dissagregate_files=demand_dissagregate_data,
         demand_scaling_file=demand_scaling_data,
     output:
-        elec_demand=RESOURCES + "{interconnect}/demand/{end_use}_electricity.pkl",
-        heat_demand=RESOURCES + "{interconnect}/demand/{end_use}_heating.pkl",
-        space_heat_demand=RESOURCES
-        + "{interconnect}/demand/{end_use}_space-heating.pkl",
-        water_heat_demand=RESOURCES
-        + "{interconnect}/demand/{end_use}_water-heating.pkl",
-        cool_demand=RESOURCES + "{interconnect}/demand/{end_use}_cooling.pkl",
+        electricity=RESOURCES + "{interconnect}/demand/{end_use}_electricity.pkl",
+        space_heat=RESOURCES + "{interconnect}/demand/{end_use}_space-heating.pkl",
+        water_heat=RESOURCES + "{interconnect}/demand/{end_use}_water-heating.pkl",
+        cool=RESOURCES + "{interconnect}/demand/{end_use}_cooling.pkl",
+    log:
+        LOGS + "{interconnect}/demand/{end_use}_build_demand.log",
+    benchmark:
+        BENCHMARKS + "{interconnect}/demand/{end_use}_build_demand"
+    threads: 2
+    resources:
+        mem_mb=lambda wildcards, input, attempt: (input.size // 70000) * attempt * 2,
+    script:
+        "../scripts/build_demand.py"
+
+
+rule build_industry_demand:
+    wildcard_constraints:
+        end_use="industry",
+    params:
+        planning_horizons=config_provider("scenario", "planning_horizons"),
+        profile_year=pd.to_datetime(config["snapshots"]["start"]).year,
+        eia_api=config_provider("api", "eia"),
+        snapshots=config_provider("snapshots"),
+        pudl_path=config_provider("pudl_path"),
+    input:
+        network=RESOURCES + "{interconnect}/elec_base_network.nc",
+        demand_files=demand_raw_data,
+        dissagregate_files=demand_dissagregate_data,
+        demand_scaling_file=demand_scaling_data,
+    output:
+        electricity=RESOURCES + "{interconnect}/demand/{end_use}_electricity.pkl",
+        heat=RESOURCES + "{interconnect}/demand/{end_use}_heating.pkl",
     log:
         LOGS + "{interconnect}/demand/{end_use}_build_demand.log",
     benchmark:
@@ -382,17 +407,10 @@ rule build_transport_road_demand:
         dissagregate_files=demand_dissagregate_data,
         demand_scaling_file=demand_scaling_data,
     output:
-        elec_light_duty=RESOURCES
-        + "{interconnect}/demand/{end_use}_light-duty_electricity.pkl",
-        elec_med_duty=RESOURCES
-        + "{interconnect}/demand/{end_use}_med-duty_electricity.pkl",
-        elec_heavy_duty=RESOURCES
-        + "{interconnect}/demand/{end_use}_heavy-duty_electricity.pkl",
-        elec_bus=RESOURCES + "{interconnect}/demand/{end_use}_bus_electricity.pkl",
-        lpg_light_duty=RESOURCES + "{interconnect}/demand/{end_use}_light-duty_lpg.pkl",
-        lpg_med_duty=RESOURCES + "{interconnect}/demand/{end_use}_med-duty_lpg.pkl",
-        lpg_heavy_duty=RESOURCES + "{interconnect}/demand/{end_use}_heavy-duty_lpg.pkl",
-        lpg_bus=RESOURCES + "{interconnect}/demand/{end_use}_bus_lpg.pkl",
+        light_duty=RESOURCES + "{interconnect}/demand/{end_use}_light-duty.pkl",
+        med_duty=RESOURCES + "{interconnect}/demand/{end_use}_med-duty.pkl",
+        heavy_duty=RESOURCES + "{interconnect}/demand/{end_use}_heavy-duty.pkl",
+        bus=RESOURCES + "{interconnect}/demand/{end_use}_bus.pkl",
     log:
         LOGS + "{interconnect}/demand/{end_use}_build_demand.log",
     benchmark:

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -471,30 +471,16 @@ def demand_to_add(wildcards):
         ]
         # road transport demands
         vehicles = ["light-duty", "med-duty", "heavy-duty", "bus"]
-        fuels = ["lpg", "electricity"]
         road_demand = [
-            RESOURCES
-            + "{interconnect}/demand/transport_"
-            + vehicle
-            + "_"
-            + fuel
-            + ".pkl"
+            RESOURCES + "{interconnect}/demand/transport_" + vehicle + ".pkl"
             for vehicle in vehicles
-            for fuel in fuels
         ]
 
         # other transport demands
         vehicles = ["boat-shipping", "rail-shipping", "rail-passenger", "air"]
-        fuels = ["lpg"]
         non_road_demand = [
-            RESOURCES
-            + "{interconnect}/demand/transport_"
-            + vehicle
-            + "_"
-            + fuel
-            + ".pkl"
+            RESOURCES + "{interconnect}/demand/transport_" + vehicle + ".pkl"
             for vehicle in vehicles
-            for fuel in fuels
         ]
 
         return chain(service_demands, industrial_demands, road_demand, non_road_demand)

--- a/workflow/rules/build_sector.smk
+++ b/workflow/rules/build_sector.smk
@@ -30,9 +30,7 @@ def sector_input_files(wildcards):
             + "{interconnect}/cop_air_urban_elec_s{simpl}_c{clusters}.nc",
             "clustered_pop_layout": RESOURCES
             + "{interconnect}/pop_layout_elec_s{simpl}_c{clusters}.csv",
-            "ev_policy": config["sector"]["transport_sector"]["investment"][
-                "ev_policy"
-            ],
+            "ev_policy": config["sector"]["transport_sector"]["ev_policy"],
             "residential_stock": "repo_data/sectors/residential_stock",
             "commercial_stock": "repo_data/sectors/commercial_stock",
             "industrial_stock": "repo_data/sectors/industrial_stock/Table5_6.xlsx",

--- a/workflow/scripts/add_demand.py
+++ b/workflow/scripts/add_demand.py
@@ -12,28 +12,12 @@ import pandas as pd
 import pypsa
 from _helpers import configure_logging, get_multiindex_snapshots, mock_snakemake
 from constants_sector import (
-    AirTransport,
-    BoatTransport,
-    RailTransport,
-    RoadTransport,
+    TRANSPORT_FUELS,
     SecCarriers,
     SecNames,
-    Transport,
 )
 
 logger = logging.getLogger(__name__)
-
-# TODO: replace with just constants through naming in build demand
-VEHICLE_MAPPER = {
-    "bus": f"{Transport.ROAD.value}-{RoadTransport.BUS.value}",
-    "heavy_duty": f"{Transport.ROAD.value}-{RoadTransport.HEAVY.value}",
-    "light_duty": f"{Transport.ROAD.value}-{RoadTransport.LIGHT.value}",
-    "med_duty": f"{Transport.ROAD.value}-{RoadTransport.MEDIUM.value}",
-    "air": f"{Transport.AIR.value}-{AirTransport.PASSENGER.value}",
-    "rail_shipping": f"{Transport.RAIL.value}-{RailTransport.SHIPPING.value}",
-    "rail_passenger": f"{Transport.RAIL.value}-{RailTransport.PASSENGER.value}",
-    "boat_shipping": f"{Transport.BOAT.value}-{BoatTransport.SHIPPING.value}",
-}
 
 
 def attach_demand(n: pypsa.Network, df: pd.DataFrame, carrier: str, suffix: str):
@@ -99,21 +83,12 @@ if __name__ == "__main__":
                 sec_name = SecNames[sector].value
                 sec_car = SecCarriers[end_use].value
 
-                carrier = f"{sec_name}-{sec_car}"
+                if sector == "transport":
+                    carrier = f"{sec_name}-{sec_car}-{TRANSPORT_FUELS[end_use]}"
+                else:
+                    carrier = f"{sec_name}-{sec_car}"
 
                 log_statement = f"{sector} {end_use} demand added to network"
-
-            elif len(parsed_name) == 3:
-                sector = parsed_name[0].upper()
-                subsector = parsed_name[1].replace("-", "_")
-                end_use = parsed_name[2].upper()  # lpg | elec
-
-                sec_name = SecNames[sector].value
-                sec_car = SecCarriers[end_use].value
-
-                carrier = f"{sec_name}-{sec_car}-{VEHICLE_MAPPER[subsector]}"
-
-                log_statement = f"{sector} {subsector} {end_use} demand added to network"
 
             else:
                 raise NotImplementedError

--- a/workflow/scripts/add_demand.py
+++ b/workflow/scripts/add_demand.py
@@ -81,12 +81,12 @@ if __name__ == "__main__":
                 end_use = parsed_name[1].upper().replace("-", "_")
 
                 sec_name = SecNames[sector].value
-                sec_car = SecCarriers[end_use].value
-
-                if sector == "transport":
-                    carrier = f"{sec_name}-{sec_car}-{TRANSPORT_FUELS[end_use]}"
+                if sector.lower() == "transport":  # hack for now to get names to work
+                    sec_car = TRANSPORT_FUELS[end_use.lower()]
                 else:
-                    carrier = f"{sec_name}-{sec_car}"
+                    sec_car = SecCarriers[end_use].value
+
+                carrier = f"{sec_name}-{sec_car}"
 
                 log_statement = f"{sector} {end_use} demand added to network"
 

--- a/workflow/scripts/add_sectors.py
+++ b/workflow/scripts/add_sectors.py
@@ -511,10 +511,10 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "add_sectors",
             interconnect="western",
-            simpl="12",
-            clusters="4m",
+            simpl="100",
+            clusters="33m",
             ll="v1.0",
-            opts="REM-12h",
+            opts="4h",
             sector="E-G",
         )
     configure_logging(snakemake)

--- a/workflow/scripts/add_sectors.py
+++ b/workflow/scripts/add_sectors.py
@@ -745,6 +745,4 @@ if __name__ == "__main__":
     # Needed as loads may be split off to urban/rural
     sanitize_carriers(n, snakemake.config)
 
-    print("y")
-
     n.export_to_netcdf(snakemake.output.network)

--- a/workflow/scripts/add_sectors.py
+++ b/workflow/scripts/add_sectors.py
@@ -27,7 +27,7 @@ from build_stock_data import (
     get_residential_stock,
     get_transport_stock,
 )
-from build_transportation import apply_exogenous_ev_policy, build_transportation
+from build_transportation import build_transportation
 from constants import CODE_2_STATE, NG_MWH_2_MMCF, STATE_2_CODE, STATES_INTERCONNECT_MAPPER
 from constants_sector import RoadTransport
 from eia import FuelCosts
@@ -511,10 +511,10 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "add_sectors",
             interconnect="western",
-            simpl="11",
+            simpl="12",
             clusters="4m",
             ll="v1.0",
-            opts="4h",
+            opts="REM-12h",
             sector="E-G",
         )
     configure_logging(snakemake)
@@ -643,19 +643,12 @@ if __name__ == "__main__":
         )
 
     # add transportation
-    trn_options = options = snakemake.params.sector["transport_sector"]
-    exogenous_transport = trn_options["investment"].get("exogenous", False)
-    if exogenous_transport:
-        ev_policy = pd.read_csv(snakemake.input.ev_policy, index_col=0)
-        apply_exogenous_ev_policy(n, ev_policy)
-        must_run_evs = None
-    else:
-        must_run_evs = trn_options["investment"].get("must_run_evs", True)
+    trn_options = snakemake.params.sector["transport_sector"]
+    must_run_evs = trn_options.get("must_run_evs", True)
     dr_config = trn_options.get("demand_response", {})
     build_transportation(
         n=n,
         costs=costs,
-        exogenous=exogenous_transport,
         must_run_evs=must_run_evs,
         dr_config=dr_config,
     )
@@ -681,7 +674,6 @@ if __name__ == "__main__":
                 growth_multiplier,
                 ratios,
                 costs,
-                exogenous_transport,
             )
 
     if snakemake.params.sector["service_sector"]["brownfield"]:

--- a/workflow/scripts/add_sectors.py
+++ b/workflow/scripts/add_sectors.py
@@ -745,4 +745,6 @@ if __name__ == "__main__":
     # Needed as loads may be split off to urban/rural
     sanitize_carriers(n, snakemake.config)
 
+    print("y")
+
     n.export_to_netcdf(snakemake.output.network)

--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -1630,6 +1630,7 @@ class WriteStrategy(ABC):
             dissag_load = load_per_bus.mul(laf.laf, axis=0).dropna()
             assert dissag_load.shape == load_per_bus.shape  # ensure no data is lost
             dissag_load = dissag_load.T  # set snapshot as index
+            dissag_load = dissag_load.loc[:, (dissag_load != 0).any(axis=0)]
             all_load.append(dissag_load)
 
         load = pd.concat(all_load, axis=1)

--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -2299,7 +2299,7 @@ if __name__ == "__main__":
             "build_transport_other_demand",
             interconnect="western",
             end_use="transport",
-            vehicle="rail-passenger",
+            vehicle="boat-shipping",
         )
         # snakemake = mock_snakemake(
         #     "build_transport_road_demand",
@@ -2476,7 +2476,7 @@ if __name__ == "__main__":
         for fuel in fuels:
             try:
                 out_f = snakemake.output[fuel]
-            except KeyError as e:  # non-road transport is not indexed by fuel
+            except AttributeError as e:  # non-road transport is not indexed by fuel
                 if len(snakemake.output) == 1:
                     out_f = snakemake.output[0]
                 else:

--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -18,7 +18,7 @@ import pandas as pd
 import pypsa
 import xarray as xr
 from _helpers import configure_logging, get_multiindex_snapshots
-from constants_sector import FIPS_2_STATE, NAICS, VMT_UNIT_CONVERSION
+from constants_sector import FIPS_2_STATE, NAICS, VMT_UNIT_CONVERSION, DemandFuels
 from eia import EnergyDemand, TransportationDemand
 
 logger = logging.getLogger(__name__)
@@ -94,42 +94,6 @@ class Context:
 
         return data
 
-    def prepare_demand_by_subsector(
-        self,
-        sector: str,
-        fuels: str | list[str],
-        **kwargs,
-    ) -> dict[str, dict[str, pd.DataFrame]]:
-        """
-        Returns demand by end-use energy carrier and subsector.
-
-        For example:
-        > result = context.prepare_demand_by_subsector("transport", ["electricity", "lpg"])
-        > result["electricity"]["light-duty"]
-        > result["lpg"]["heavy-duty"]
-        """
-        if isinstance(fuels, str):
-            fuels = [fuels]
-
-        demand = self._read()
-        demand_sector = demand[demand.index.get_level_values("sector") == sector]
-        subsectors = demand_sector.index.get_level_values("subsector").unique()
-
-        data = {}
-        for fuel in fuels:
-            data[fuel] = {}
-            for subsector in subsectors:
-                data[fuel][subsector] = self._write(
-                    demand,
-                    self._read_strategy.zone,
-                    sector=sector,
-                    subsector=subsector,
-                    fuel=fuel,
-                    **kwargs,
-                )
-
-        return data
-
 
 ###
 # READ STRATEGIES
@@ -195,10 +159,8 @@ class ReadStrategy(ABC):
             for x in df.index.get_level_values("sector").unique()
         )
 
-        assert all(
-            x in ["all", "electricity", "heat", "cool", "lpg", "space_heat", "water_heat"]
-            for x in df.index.get_level_values("fuel").unique()
-        )
+        valid_fuels = [x.value for x in DemandFuels]
+        assert all(x in valid_fuels for x in df.index.get_level_values("fuel").unique())
 
     @staticmethod
     def _format_snapshot_index(df: pd.DataFrame) -> pd.DataFrame:
@@ -1040,14 +1002,13 @@ class ReadCliu(ReadStrategy):
 
 
 class ReadTransportEfsAeo(ReadStrategy):
-    """
-    Calculates 100% VMT road demand for both electricity and lpg.
+    """EFS and AEO data for transportation.
 
     This will take EFS charging profiles and apply state level VMT
     statistics to calculate 100% electrified profiles.
 
-    Honestly, this is kinda an awkward implementation. But is works, so
-    it is what it is at this point.
+    Operational requirements to meet this load curve from both LPG and EVs are
+    applied in 'add_sectors.py' via 'build_transportation.py'
 
     - filepath: str
         path to a user defined file that has breakdown of state level VMT by
@@ -1133,6 +1094,34 @@ class ReadTransportEfsAeo(ReadStrategy):
 
         return df
 
+    @staticmethod
+    def _uniform_if_empty(df: pd.DataFrame) -> pd.DataFrame:
+        """Uniform distribution if all values are 0 per year.
+
+        Checks at a per year and per vehicle class level.
+        """
+        years = df.index.get_level_values("snapshot").year.unique()
+        vehicles = df.index.get_level_values("subsector").unique()
+        dfs = []
+        for year in years:
+            yearly_dfs = []
+            for vehicle in vehicles:
+                temp = df[
+                    (df.index.get_level_values("snapshot").year == year)
+                    & (df.index.get_level_values("subsector") == vehicle)
+                ].copy()
+                for state in temp.columns:
+                    if temp[state].sum() < 0.999:
+                        temp[state] = round(1 / len(temp), 8)
+                yearly_dfs.append(temp)
+            yearly_df = pd.concat(yearly_dfs)
+            dfs.append(yearly_df)
+
+        adjusted = pd.concat(dfs)
+        assert df.shape == adjusted.shape  # no data should be lost
+
+        return adjusted.reindex_like(df)
+
     def _read_efs_data(self):
         """
         Extracts profile data.
@@ -1166,6 +1155,9 @@ class ReadTransportEfsAeo(ReadStrategy):
         transport = transport.set_index([transport.index, "subsector"]).reorder_levels(
             index_order,
         )
+
+        # if a vehicle does not have a charging profile, swap to uniform distribution
+        transport = self._uniform_if_empty(transport)
 
         return transport
 
@@ -1205,24 +1197,22 @@ class ReadTransportEfsAeo(ReadStrategy):
 
         return vmt_demand
 
-    def _format_data(self, data: pd.DataFrame) -> pd.DataFrame:
+    def _format_data(self, vmt_per_state: pd.DataFrame) -> pd.DataFrame:
         """
         Merges national VMT data (self.aeo_demand), proportions of VMT
-        travelled per state (data), and electric charging profiles
+        travelled per state (vmt_per_state), and electric charging profiles
         (self.efs_profile).
-
-        This is one ugly function. holy.
         """
         aeo = self.aeo_demand.drop(columns="units")
         aeo = xr.DataArray.from_series(aeo.squeeze())
 
-        ds = xr.Dataset.from_dataframe(data)  # (vehicle, state)
+        ds = xr.Dataset.from_dataframe(vmt_per_state)  # (vehicle, state)
         ds = ds.sel(vehicle=aeo.vehicle.values)
 
         ds["yearly_demand"] = aeo  # (vehicle, year)
         ds["yearly_demand_per_state"] = ds.percent * ds.yearly_demand * (1 / 100)  # (vehicle, year, state)
 
-        efs = (
+        efs_profile = (
             self.efs_profile.reset_index()
             .melt(
                 id_vars=["snapshot", "subsector"],
@@ -1231,16 +1221,11 @@ class ReadTransportEfsAeo(ReadStrategy):
             )
             .rename(columns={"subsector": "vehicle"})
             .set_index(["snapshot", "vehicle", "state"])
+            .squeeze()
         )
-        elec_profile = efs.squeeze()
-        lpg_profile = elec_profile.copy()
-        lpg_profile[:] = 1 / 8760  # uniform profile assumption
 
-        ds["elec_profile"] = xr.DataArray.from_series(
-            elec_profile,
-        )  # (snapshot, vehicle, state)
-        ds["lpg_profile"] = xr.DataArray.from_series(
-            lpg_profile,
+        ds["profile"] = xr.DataArray.from_series(
+            efs_profile,
         )  # (snapshot, vehicle, state)
 
         # I think there is probably a more efficienct way to do this, I just couldnt figure out
@@ -1248,41 +1233,24 @@ class ReadTransportEfsAeo(ReadStrategy):
         # (ie. not having snapshots in 2018 indexed over years other than 2018)
         dfs = []
         for year in self.efs_years:
-            elec_demand = ds.yearly_demand_per_state.sel(
+            demand = ds.yearly_demand_per_state.sel(
                 year=year,
-            ) * ds.elec_profile.sel(
+            ) * ds.profile.sel(
                 snapshot=f"{year}",
             )
-            elec_demand = pd.DataFrame(
-                elec_demand.dropna(dim="state").to_series(),
+            demand = pd.DataFrame(
+                demand.dropna(dim="state").to_series(),
                 columns=["value"],
             ).reset_index()
-            elec_demand = elec_demand.rename(columns={"vehicle": "subsector"})
-            elec_demand["sector"] = "transport"
-            elec_demand["fuel"] = "electricity"
-            elec_demand = elec_demand.pivot(
+            demand = demand.rename(columns={"vehicle": "fuel"})
+            demand["sector"] = "transport"
+            demand["subsector"] = "all"
+            demand = demand.pivot(
                 columns="state",
                 index=["snapshot", "sector", "subsector", "fuel"],
                 values="value",
             )
-
-            lpg_demand = ds.yearly_demand_per_state.sel(year=year) * ds.lpg_profile.sel(
-                snapshot=f"{year}",
-            )
-            lpg_demand = pd.DataFrame(
-                lpg_demand.dropna(dim="state").to_series(),
-                columns=["value"],
-            ).reset_index()
-            lpg_demand = lpg_demand.rename(columns={"vehicle": "subsector"})
-            lpg_demand["sector"] = "transport"
-            lpg_demand["fuel"] = "lpg"
-            lpg_demand = lpg_demand.pivot(
-                columns="state",
-                index=["snapshot", "sector", "subsector", "fuel"],
-                values="value",
-            )
-
-            dfs.extend([elec_demand, lpg_demand])
+            dfs.append(demand)
 
         return pd.concat(dfs)
 
@@ -1623,6 +1591,7 @@ class WriteStrategy(ABC):
 
         for load_zone in laf.zone.unique():
             load = laf[laf.zone == load_zone]
+            load = load[~(load.laf < 0.000001)].copy()  # drop any buses that have zero load
             load_per_bus = pd.DataFrame(
                 data=([demand[load_zone]] * len(load.index)),
                 index=load.index,
@@ -1630,7 +1599,6 @@ class WriteStrategy(ABC):
             dissag_load = load_per_bus.mul(laf.laf, axis=0).dropna()
             assert dissag_load.shape == load_per_bus.shape  # ensure no data is lost
             dissag_load = dissag_load.T  # set snapshot as index
-            dissag_load = dissag_load.loc[:, (dissag_load != 0).any(axis=0)]
             all_load.append(dissag_load)
 
         load = pd.concat(all_load, axis=1)
@@ -2281,6 +2249,23 @@ def _get_closest_efs_year(efs_years, investment_period):
     return max(filtered_values)
 
 
+def _get_sector_fuels(end_use: str) -> list[str]:
+    """Get sector fuels."""
+    demand = DemandFuels
+    match end_use:
+        case "residential":
+            fuels = [demand.ELECTRICITY, demand.SPACE_HEATING, demand.SPACE_COOLING, demand.WATER_HEATING]
+        case "commercial":
+            fuels = [demand.ELECTRICITY, demand.SPACE_HEATING, demand.SPACE_COOLING, demand.WATER_HEATING]
+        case "industry":
+            fuels = [demand.ELECTRICITY, demand.HEATING]
+        case "transport":
+            fuels = [demand.LIGHT, demand.MEDIUM, demand.HEAVY, demand.BUS]
+        case _:
+            raise NotImplementedError
+    return [x.value for x in fuels]
+
+
 ###
 # main entry point
 ###
@@ -2434,16 +2419,8 @@ if __name__ == "__main__":
     if end_use == "power":  # only one demand for electricity only studies
         demand = demand_converter.prepare_demand(sns=sns)  # pd.DataFrame
         demands = {"electricity": demand}
-    elif end_use == "transport":
-        # only road transport has specific electrical profiles
-        fuels = ("electricity", "lpg") if not vehicle else ("lpg")
-        demands = demand_converter.prepare_demand_by_subsector(
-            end_use,
-            fuels,
-            sns=sns,
-        )  # dict[str, dict[str, pd.DataFrame]]
     else:
-        fuels = ("electricity", "heat", "cool", "space_heat", "water_heat")
+        fuels = _get_sector_fuels(end_use)
         demands = demand_converter.prepare_multiple_demands(
             end_use,  # residential, commercial, industry, transport
             fuels,
@@ -2465,16 +2442,10 @@ if __name__ == "__main__":
     )
 
     formatted_demand = {}
-    # transport is by subsector
-    if end_use == "transport":
-        for fuel, _ in demands.items():
-            formatted_demand[fuel] = {}
-            for vehicle_type, demand in demands[fuel].items():
-                vmt_conversion = VMT_UNIT_CONVERSION.get(vehicle_type, 1)
-                formatted_demand[fuel][vehicle_type] = demand_formatter.format_demand(
-                    demand,
-                    vehicle_type,
-                ).mul(vmt_conversion)
+    if end_use == "transport":  # transport fuel is actually vehicle types
+        for fuel, demand in demands.items():
+            vmt_conversion = VMT_UNIT_CONVERSION.get(fuel, 1)  # for buses
+            formatted_demand[fuel] = demand_formatter.format_demand(demand, fuel).mul(vmt_conversion)
     else:
         for fuel, demand in demands.items():
             formatted_demand[fuel] = demand_formatter.format_demand(demand, end_use)
@@ -2485,33 +2456,8 @@ if __name__ == "__main__":
             snakemake.output.elec_demand,
             index=True,
         )
-    # transport demand is by subsector
-    elif end_use == "transport":
-        if not vehicle:  # road transport
-            file_mapper = {"electricity": "elec", "lpg": "lpg"}
-            for fuel in ("electricity", "lpg"):
-                for vehicle_type in ("light_duty", "med_duty", "heavy_duty", "bus"):
-                    formatted_demand[fuel][vehicle_type].round(4).to_pickle(
-                        snakemake.output[f"{file_mapper[fuel]}_{vehicle_type}"],
-                    )
-        else:  # "boat_shipping", "air", "rail_passenger", "rail_shipping"
-            formatted_demand["lpg"][vehicle.replace("-", "_")].round(4).to_pickle(
-                snakemake.output[0],
-            )
-
     else:
-        formatted_demand["electricity"].round(4).to_pickle(
-            snakemake.output.elec_demand,
-        )
-        formatted_demand["heat"].round(4).to_pickle(
-            snakemake.output.heat_demand,
-        )
-        formatted_demand["space_heat"].round(4).to_pickle(
-            snakemake.output.space_heat_demand,
-        )
-        formatted_demand["water_heat"].round(4).to_pickle(
-            snakemake.output.water_heat_demand,
-        )
-        formatted_demand["cool"].round(4).to_pickle(
-            snakemake.output.cool_demand,
-        )
+        for fuel in fuels:
+            formatted_demand[fuel].round(4).to_pickle(
+                snakemake.output[fuel],
+            )

--- a/workflow/scripts/build_stock_data.py
+++ b/workflow/scripts/build_stock_data.py
@@ -683,7 +683,7 @@ def _get_brownfield_template_df(
     return df[["bus1", "name", "suffix", "state", "p_max"]]
 
 
-def _get_endogenous_transport_brownfield_template_df(
+def _get_transport_brownfield_template_df(
     n: pypsa.Network,
     fuel: str,
     veh_mode: str | None = None,
@@ -729,7 +729,6 @@ def add_road_transport_brownfield(
     growth_multiplier: float,
     ratios: pd.DataFrame,
     costs: pd.DataFrame,
-    exogenous_transport: bool,
 ) -> None:
     """Adds existing stock to transportation sector."""
 
@@ -904,47 +903,23 @@ def add_road_transport_brownfield(
     elec_fuel = SecCarriers.ELECTRICITY.value
     lpg_fuel = SecCarriers.LPG.value
 
-    if exogenous_transport:
-        veh_name = f"{veh_type}-{vehicle_mode}"
+    # elec brownfield
+    df = _get_transport_brownfield_template_df(
+        n,
+        fuel=elec_fuel,
+        veh_mode=vehicle_mode,
+    )
+    df["p_nom"] = df.p_max.mul(growth_multiplier)
+    add_brownfield_ev(n, df, vehicle_mode, ratios, costs)
 
-        # ev brownfield
-        df = _get_brownfield_template_df(
-            n,
-            fuel=elec_fuel,
-            sector=sector,
-            subsector=veh_name,
-        )
-        df["p_nom"] = df.p_max.mul(growth_multiplier)
-        add_brownfield_ev(n, df, vehicle_mode, ratios, costs)
-
-        # lpg brownfield
-        df = _get_brownfield_template_df(
-            n,
-            fuel=lpg_fuel,
-            sector=sector,
-            subsector=veh_name,
-        )
-        df["p_nom"] = df.p_max.mul(growth_multiplier)
-        add_brownfield_lpg(n, df, vehicle_mode, ratios, costs)
-
-    else:
-        # elec brownfield
-        df = _get_endogenous_transport_brownfield_template_df(
-            n,
-            fuel=elec_fuel,
-            veh_mode=vehicle_mode,
-        )
-        df["p_nom"] = df.p_max.mul(growth_multiplier)
-        add_brownfield_ev(n, df, vehicle_mode, ratios, costs)
-
-        # lpg brownfield
-        df = _get_endogenous_transport_brownfield_template_df(
-            n,
-            fuel=lpg_fuel,
-            veh_mode=vehicle_mode,
-        )
-        df["p_nom"] = df.p_max.mul(growth_multiplier)
-        add_brownfield_lpg(n, df, vehicle_mode, ratios, costs)
+    # lpg brownfield
+    df = _get_transport_brownfield_template_df(
+        n,
+        fuel=lpg_fuel,
+        veh_mode=vehicle_mode,
+    )
+    df["p_nom"] = df.p_max.mul(growth_multiplier)
+    add_brownfield_lpg(n, df, vehicle_mode, ratios, costs)
 
 
 def add_service_brownfield(

--- a/workflow/scripts/build_stock_data.py
+++ b/workflow/scripts/build_stock_data.py
@@ -818,7 +818,7 @@ def add_road_transport_brownfield(
         # https://data.nrel.gov/submissions/93
         # https://www.nrel.gov/docs/fy18osti/70485.pdf
 
-        ## Efficiencies of existing stock are quite sensitive!
+        ## Efficiencies of existing stock are quite sensitive! ##
 
         match vehicle_mode:
             case RoadTransport.LIGHT.value:

--- a/workflow/scripts/build_stock_data.py
+++ b/workflow/scripts/build_stock_data.py
@@ -814,26 +814,31 @@ def add_road_transport_brownfield(
     ) -> None:
         # existing stock efficiencies taken from 2016 EFS Technology data
         # This is consistent with where future efficiencies are taken from
+        # Historical uses lowest EIA 2017 case where available
         # https://data.nrel.gov/submissions/93
         # https://www.nrel.gov/docs/fy18osti/70485.pdf
+
+        ## Efficiencies of existing stock are quite sensitive!
 
         match vehicle_mode:
             case RoadTransport.LIGHT.value:
                 costs_name = "Light Duty Cars ICEV"
                 ratio_name = "light_duty"
-                efficiency = 25.9  # mpg
+                efficiency = 37.78  # mpg (Table 6)
+                # efficiency = 29.2  # mpg (AEO Table 42)
             case RoadTransport.MEDIUM.value:
                 costs_name = "Medium Duty Trucks ICEV"
                 ratio_name = "med_duty"
-                efficiency = 16.35  # mpg
+                efficiency = 25.16  # mpg (Table 7)
+                # efficiency = 22.8  # mpg (AEO Table 42)
             case RoadTransport.HEAVY.value:
                 costs_name = "Heavy Duty Trucks ICEV"
                 ratio_name = "heavy_duty"
-                efficiency = 5.44  # mpg
+                efficiency = 5.67  # mpg (Table 10)
             case RoadTransport.BUS.value:
                 costs_name = "Buses ICEV"
                 ratio_name = "bus"
-                efficiency = 3.67  # mpg
+                efficiency = 3.92  # mpg (Table 12)
             case _:
                 raise NotImplementedError
 

--- a/workflow/scripts/build_stock_data.py
+++ b/workflow/scripts/build_stock_data.py
@@ -776,9 +776,9 @@ def add_road_transport_brownfield(
         periods = int(lifetime // step)
 
         start_year = n.investment_periods[0]
-        start_year = start_year if start_year >= 2023 else 2023
+        start_year = start_year if start_year <= 2025 else 2025
 
-        for period in range(1, periods + 1):
+        for period in range(0, periods):
             build_year = start_year - period * step
             percent = step / lifetime  # given as a ratio
 
@@ -866,9 +866,9 @@ def add_road_transport_brownfield(
         periods = int(lifetime // step)
 
         start_year = n.investment_periods[0]
-        # start_year = start_year if start_year >= 2023 else 2023
+        start_year = start_year if start_year <= 2025 else 2025
 
-        for period in range(1, periods + 1):
+        for period in range(0, periods):
             build_year = start_year - period * step
             percent = step / lifetime  # given as a ratio
 
@@ -895,6 +895,28 @@ def add_road_transport_brownfield(
                 build_year=build_year,
             )
 
+    def add_charging_profiles(n: pypsa.Network) -> None:
+        """Add charging profiles to the network.
+
+        The existing stock has the same charing profile as the future stock.
+        """
+        trn = n.links[n.links.carrier.str.startswith("trn")]
+        trn_existing = trn[trn.index.str.contains("existing_")]
+
+        for vehicle in trn_existing.index:
+            # vehicle will have the form 'p10 existing_2008 trn-elec-veh-lgt'
+            ref_vehicle_split = vehicle.split(" ")
+            ref_vehicle = ref_vehicle_split[0] + " " + ref_vehicle_split[2]
+
+            # can run into infeasabilities for validation runs with the electrification policy
+            # if ref_vehicle in n.links_t["p_min_pu"]:
+            #     p_min_pu = n.links_t["p_min_pu"][ref_vehicle]
+            #     n.links_t["p_min_pu"][vehicle] = p_min_pu
+
+            if ref_vehicle in n.links_t["p_max_pu"]:
+                p_max_pu = n.links_t["p_max_pu"][ref_vehicle]
+                n.links_t["p_max_pu"][vehicle] = p_max_pu
+
     # different naming conventions for exogenous/endogenous transport investment
 
     sector = SecNames.TRANSPORT.value
@@ -911,6 +933,9 @@ def add_road_transport_brownfield(
     )
     df["p_nom"] = df.p_max.mul(growth_multiplier)
     add_brownfield_ev(n, df, vehicle_mode, ratios, costs)
+
+    # charging profiles of existing stock match the future stock
+    add_charging_profiles(n)
 
     # lpg brownfield
     df = _get_transport_brownfield_template_df(
@@ -968,7 +993,7 @@ def add_service_brownfield(
         df["p_nom"] = df.p_max.mul(df.ratio).div(100).div(efficiency).round(2)  # div to convert from %
 
         start_year = n.investment_periods[0]
-        # start_year if start_year >= 2023 else 2023
+        start_year = start_year if start_year <= 2025 else 2025
 
         for build_year, percent in installed_capacity.items():
             if _already_retired(build_year, lifetime, start_year):
@@ -1032,7 +1057,7 @@ def add_service_brownfield(
         df["p_nom"] = df.p_max.mul(df.ratio).div(100).div(efficiency)  # div to convert from %
 
         start_year = n.investment_periods[0]
-        # start_year = start_year if start_year >= 2023 else 2023
+        start_year = start_year if start_year <= 2025 else 2025
 
         for build_year, percent in installed_capacity.items():
             if _already_retired(build_year, lifetime, start_year):
@@ -1092,7 +1117,7 @@ def add_service_brownfield(
         df["p_nom"] = df.p_max.mul(df.ratio).div(100).div(efficiency)  # div to convert from %
 
         start_year = n.investment_periods[0]
-        # start_year = start_year if start_year >= 2023 else 2023
+        start_year = start_year if start_year <= 2025 else 2025
 
         for build_year, percent in installed_capacity.items():
             if _already_retired(build_year, lifetime, start_year):
@@ -1157,7 +1182,7 @@ def add_service_brownfield(
         df["p_nom"] = df.p_max.mul(df.ratio).div(100).div(efficiency).round(2)  # div to convert from %
 
         start_year = n.investment_periods[0]
-        # start_year = start_year if start_year >= 2023 else 2023
+        start_year = start_year if start_year <= 2025 else 2025
 
         for build_year, percent in installed_capacity.items():
             if _already_retired(build_year, lifetime, start_year):

--- a/workflow/scripts/build_transportation.py
+++ b/workflow/scripts/build_transportation.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 def build_transportation(
     n: pypsa.Network,
     costs: pd.DataFrame,
-    exogenous: bool = False,
     air: bool = True,
     rail: bool = True,
     boat: bool = True,
@@ -41,10 +40,7 @@ def build_transportation(
     for vehicle in road_vehicles:
         add_elec_vehicle(n, road_suffix, vehicle, costs)
         add_lpg_vehicle(n, road_suffix, vehicle, costs, lpg_cost)
-
-    if not exogenous:
-        assert isinstance(must_run_evs, bool)
-        apply_endogenous_road_investments(n, must_run_evs)
+    constrain_charing_rates(n, must_run_evs)
 
     # demand response must happen after exogenous/endogenous split
     if dr_config:
@@ -333,16 +329,16 @@ def add_elec_vehicle(
     lifetime = costs.at[costs_name, "lifetime"]
     build_year = n.investment_periods[0]
 
-    carrier_name = f"trn-elec-{vehicle}-{mode}"
+    carrier_name = f"trn-{vehicle}-{mode}"
 
     loads = n.loads[n.loads.carrier == carrier_name]
 
     vehicles = pd.DataFrame(index=loads.bus)
     vehicles.index = vehicles.index.map(
-        lambda x: x.split(f" trn-elec-{vehicle}-{mode}")[0],
+        lambda x: x.split(f" trn-{vehicle}-{mode}")[0],
     )
     vehicles["bus0"] = vehicles.index + f" trn-elec-{vehicle}"
-    vehicles["bus1"] = vehicles.index + f" trn-elec-{vehicle}-{mode}"
+    vehicles["bus1"] = vehicles.index + f" trn-{vehicle}-{mode}"
     vehicles["carrier"] = f"trn-elec-{vehicle}-{mode}"
 
     n.madd(
@@ -399,17 +395,17 @@ def add_lpg_vehicle(
     lifetime = costs.at[costs_name, "lifetime"]
     build_year = n.investment_periods[0]
 
-    carrier_name = f"trn-lpg-{vehicle}-{mode}"
+    carrier_name = f"trn-{vehicle}-{mode}"
 
     loads = n.loads[n.loads.carrier == carrier_name]
 
     vehicles = pd.DataFrame(index=loads.bus)
     vehicles["state"] = vehicles.index.map(n.buses.STATE)
     vehicles.index = vehicles.index.map(
-        lambda x: x.split(f" trn-lpg-{vehicle}-{mode}")[0],
+        lambda x: x.split(f" trn-{vehicle}-{mode}")[0],
     )
     vehicles["bus0"] = vehicles.index + f" trn-lpg-{vehicle}"
-    vehicles["bus1"] = vehicles.index + f" trn-lpg-{vehicle}-{mode}"
+    vehicles["bus1"] = vehicles.index + f" trn-{vehicle}-{mode}"
     vehicles["carrier"] = f"trn-lpg-{vehicle}-{mode}"
 
     if isinstance(marginal_cost, pd.DataFrame):
@@ -585,101 +581,7 @@ def add_rail(
     )
 
 
-def _create_endogenous_buses(n: pypsa.Network) -> None:
-    """Creats new bus for grouped endogenous vehicle load."""
-    buses = n.buses[
-        n.buses.carrier.str.startswith("trn")
-        & n.buses.carrier.str.contains("veh")
-        & ~n.buses.carrier.str.endswith("veh")
-    ].copy()
-    buses["veh"] = buses.carrier.map(lambda x: x.split("-")[-1])
-    buses["name"] = buses.country + " trn-veh-" + buses.veh
-    buses["carrier"] = "trn-veh-" + buses.veh
-    buses = buses.drop_duplicates(subset="name")
-    buses = buses.set_index("name")
-
-    n.madd(
-        "Bus",
-        buses.index,
-        x=buses.x,
-        y=buses.y,
-        carrier=buses.carrier,
-        STATE=buses.STATE,
-        STATE_NAME=buses.STATE_NAME,
-        unit=buses.unit,
-        interconnect=buses.interconnect,
-        state=buses.state,
-        country=buses.country,
-        reeds_ba=buses.reeds_ba,
-        reeds_state=buses.reeds_state,
-        nerc_reg=buses.nerc_reg,
-        trans_reg=buses.trans_reg,
-    )
-
-
-def _create_endogenous_loads(n: pypsa.Network) -> None:
-    """Creates aggregated vehicle load.
-
-    - Removes LPG load
-    - Transfers EV load to central bus
-    """
-    loads = n.loads[n.loads.carrier.str.startswith("trn") & n.loads.carrier.str.contains("veh")]
-    to_remove = [x for x in loads.index if "-lpg-" in x]
-    to_shift = [x for x in loads.index if "-elec-" in x]
-    assert (len(to_remove) + len(to_shift)) == len(loads)
-
-    new_name_mapper = {x: x.replace("-elec", "") for x in to_shift}
-    new_names = [x for _, x in new_name_mapper.items()]
-
-    # remove LPG loads
-    n.mremove(
-        "Load",
-        to_remove,
-    )
-
-    # rename elec loads to general loads
-    n.loads_t["p_set"] = n.loads_t["p_set"].rename(columns=new_name_mapper)
-    n.loads = n.loads.rename(index=new_name_mapper)
-
-    # transfer elec load buses to general bus
-    n.loads.loc[new_names, "bus"] = n.loads.loc[new_names, "bus"].map(new_name_mapper)
-    n.loads.loc[new_names, "carrier"] = n.loads.loc[new_names, "carrier"].map(
-        lambda x: x.replace("trn-elec-", "trn-"),
-    )
-    n.loads.loc[new_names, "carrier"] = n.loads.loc[new_names, "carrier"].map(
-        lambda x: x.replace("trn-lpg-", "trn-"),
-    )
-
-
-def _create_endogenous_links(n: pypsa.Network) -> None:
-    """Creates links for LPG and EV to load bus.
-
-    Just involves transfering bus1 from exogenous load bus to endogenous load bus
-    """
-    slicer = (
-        n.links.carrier.str.startswith("trn")
-        & n.links.carrier.str.contains("veh")
-        & ~n.links.carrier.str.endswith("veh")
-    )
-    n.links.loc[slicer, "bus1"] = n.links.loc[slicer, "bus1"].map(
-        lambda x: x.replace("trn-elec-", "trn-"),
-    )
-    n.links.loc[slicer, "bus1"] = n.links.loc[slicer, "bus1"].map(
-        lambda x: x.replace("trn-lpg-", "trn-"),
-    )
-
-
-def _remove_exogenous_buses(n: pypsa.Network) -> None:
-    """Removes buses that are used for exogenous vehicle loads."""
-    # this is super awkward filtering :(
-    buses = n.buses[
-        (n.buses.index.str.contains("trn-elec-veh") | n.buses.index.str.contains("trn-lpg-veh"))
-        & ~(n.buses.index.str.endswith("-veh") | n.buses.index.str.endswith("-veh-store"))
-    ].index.to_list()
-    n.mremove("Bus", buses)
-
-
-def _constrain_charing_rates(n: pypsa.Network, must_run_evs: bool) -> None:
+def constrain_charing_rates(n: pypsa.Network, must_run_evs: bool) -> None:
     """Applies limits to p_min_pu/p_max_pu on links.
 
     must_run_evs:
@@ -722,29 +624,6 @@ def _constrain_charing_rates(n: pypsa.Network, must_run_evs: bool) -> None:
     p_max_pu = (p_max_pu - p_max_pu.min()) / (p_max_pu.max() - p_max_pu.min())
     p_max_pu = p_max_pu = p_max_pu.add(0.01).clip(upper=1).round(2)
     n.links_t["p_max_pu"] = pd.concat([n.links_t["p_max_pu"], p_max_pu], axis=1)
-
-
-def apply_endogenous_road_investments(
-    n: pypsa.Network,
-    must_run_evs: bool = False,
-) -> None:
-    """Merges EV and LPG load into a single load.
-
-    This function will do the following:
-    - Create a new bus that the combined load will apply to
-    - Shift the EV load to the new bus. This load will retain the EV profile and full
-      magnitude, as this represents all vehicle load in the system. The load is renamed.
-    - Remove the LPG load
-    - Create two links. 1) from EV to new bus for aggregate load. 2) from LPG to new
-      bus for aggregate load
-    - Costrain the new EV link to match the vehicle load profile
-      (ie. p_nom_min(ev) = p_nom_max(ev) = p_nom_t(load))
-    """
-    _create_endogenous_buses(n)
-    _create_endogenous_loads(n)
-    _create_endogenous_links(n)
-    _remove_exogenous_buses(n)
-    _constrain_charing_rates(n, must_run_evs)
 
 
 def apply_exogenous_ev_policy(n: pypsa.Network, policy: pd.DataFrame) -> None:

--- a/workflow/scripts/build_transportation.py
+++ b/workflow/scripts/build_transportation.py
@@ -618,9 +618,11 @@ def constrain_charing_rates(n: pypsa.Network, must_run_evs: bool) -> None:
     # add small buffer for computation issues while solving
     if not p_min_pu.empty:
         p_min_pu = (p_min_pu - p_min_pu.min()) / (p_min_pu.max() - p_min_pu.min())
+        p_min_pu = p_min_pu.fillna(0)  # if uniform profile, p_min_pu will be nan
         p_min_pu = p_min_pu.sub(0.01).clip(lower=0).round(2)
         n.links_t["p_min_pu"] = pd.concat([n.links_t["p_min_pu"], p_min_pu], axis=1)
 
     p_max_pu = (p_max_pu - p_max_pu.min()) / (p_max_pu.max() - p_max_pu.min())
+    p_max_pu = p_max_pu.fillna(1)  # if uniform profile, p_max_pu will be nan
     p_max_pu = p_max_pu = p_max_pu.add(0.01).clip(upper=1).round(2)
     n.links_t["p_max_pu"] = pd.concat([n.links_t["p_max_pu"], p_max_pu], axis=1)

--- a/workflow/scripts/constants_sector.py
+++ b/workflow/scripts/constants_sector.py
@@ -28,6 +28,33 @@ class SecCarriers(Enum):
     WATER_HEATING = "water-heat"
 
 
+######################
+# Constants for Demand
+######################
+
+
+class DemandFuels(Enum):
+    """Demand fuels."""
+
+    # residential, commercial, industry
+    ELECTRICITY = "electricity"
+    LPG = "lpg"
+    SPACE_HEATING = "space_heat"
+    SPACE_COOLING = "cool"
+    WATER_HEATING = "water_heat"
+    HEATING = "heat"
+
+    # transport
+    LIGHT = "light_duty"
+    MEDIUM = "med_duty"
+    HEAVY = "heavy_duty"
+    BUS = "bus"
+    AIR_PSG = "air"
+    BOAT_SHIP = "boat_ship"
+    RAIL_PSG = "rail_psg"
+    RAIL_SHIP = "rail_ship"
+
+
 ##############################
 # Constants for Transportation
 ##############################

--- a/workflow/scripts/constants_sector.py
+++ b/workflow/scripts/constants_sector.py
@@ -51,8 +51,8 @@ class DemandFuels(Enum):
     BUS = "bus"
     AIR_PSG = "air"
     BOAT_SHIP = "boat_ship"
-    RAIL_PSG = "rail_psg"
-    RAIL_SHIP = "rail_ship"
+    RAIL_PSG = "rail_passenger"
+    RAIL_SHIP = "rail_shipping"
 
 
 ##############################
@@ -124,6 +124,18 @@ class BoatTransportUnits(Enum):
 
     SHIPPING = "kTonMiles"
 
+
+# TODO: this is a hack to get the transport fuels into the demand file
+TRANSPORT_FUELS = {
+    DemandFuels.LIGHT: f"{Transport.ROAD.value}-{RoadTransport.LIGHT.value}",
+    DemandFuels.MEDIUM: f"{Transport.ROAD.value}-{RoadTransport.MEDIUM.value}",
+    DemandFuels.HEAVY: f"{Transport.ROAD.value}-{RoadTransport.HEAVY.value}",
+    DemandFuels.BUS: f"{Transport.ROAD.value}-{RoadTransport.BUS.value}",
+    DemandFuels.AIR_PSG: f"{Transport.AIR.value}-{AirTransport.PASSENGER.value}",
+    DemandFuels.BOAT_SHIP: f"{Transport.BOAT.value}-{BoatTransport.SHIPPING.value}",
+    DemandFuels.RAIL_PSG: f"{Transport.RAIL.value}-{RailTransport.PASSENGER.value}",
+    DemandFuels.RAIL_SHIP: f"{Transport.RAIL.value}-{RailTransport.SHIPPING.value}",
+}
 
 """
 These numbers are giving odd results :(

--- a/workflow/scripts/constants_sector.py
+++ b/workflow/scripts/constants_sector.py
@@ -50,7 +50,7 @@ class DemandFuels(Enum):
     HEAVY = "heavy_duty"
     BUS = "bus"
     AIR_PSG = "air"
-    BOAT_SHIP = "boat_ship"
+    BOAT_SHIP = "boat_shipping"
     RAIL_PSG = "rail_passenger"
     RAIL_SHIP = "rail_shipping"
 
@@ -127,14 +127,14 @@ class BoatTransportUnits(Enum):
 
 # TODO: this is a hack to get the transport fuels into the demand file
 TRANSPORT_FUELS = {
-    DemandFuels.LIGHT: f"{Transport.ROAD.value}-{RoadTransport.LIGHT.value}",
-    DemandFuels.MEDIUM: f"{Transport.ROAD.value}-{RoadTransport.MEDIUM.value}",
-    DemandFuels.HEAVY: f"{Transport.ROAD.value}-{RoadTransport.HEAVY.value}",
-    DemandFuels.BUS: f"{Transport.ROAD.value}-{RoadTransport.BUS.value}",
-    DemandFuels.AIR_PSG: f"{Transport.AIR.value}-{AirTransport.PASSENGER.value}",
-    DemandFuels.BOAT_SHIP: f"{Transport.BOAT.value}-{BoatTransport.SHIPPING.value}",
-    DemandFuels.RAIL_PSG: f"{Transport.RAIL.value}-{RailTransport.PASSENGER.value}",
-    DemandFuels.RAIL_SHIP: f"{Transport.RAIL.value}-{RailTransport.SHIPPING.value}",
+    DemandFuels.LIGHT.value: f"{Transport.ROAD.value}-{RoadTransport.LIGHT.value}",
+    DemandFuels.MEDIUM.value: f"{Transport.ROAD.value}-{RoadTransport.MEDIUM.value}",
+    DemandFuels.HEAVY.value: f"{Transport.ROAD.value}-{RoadTransport.HEAVY.value}",
+    DemandFuels.BUS.value: f"{Transport.ROAD.value}-{RoadTransport.BUS.value}",
+    DemandFuels.AIR_PSG.value: f"{Transport.AIR.value}-{AirTransport.PASSENGER.value}",
+    DemandFuels.BOAT_SHIP.value: f"{Transport.BOAT.value}-{BoatTransport.SHIPPING.value}",
+    DemandFuels.RAIL_PSG.value: f"{Transport.RAIL.value}-{RailTransport.PASSENGER.value}",
+    DemandFuels.RAIL_SHIP.value: f"{Transport.RAIL.value}-{RailTransport.SHIPPING.value}",
 }
 
 """

--- a/workflow/scripts/opts/sector.py
+++ b/workflow/scripts/opts/sector.py
@@ -585,8 +585,7 @@ def add_sector_demand_response_constraints(n, config):
 def add_ev_generation_constraint(n, config, snakemake):
     """Adds a limit to the maximum generation from EVs per mode and year.
 
-    Only applied if endogenous investments are tuned on as a mechanism to limit
-    growth rate of EVs. The constraint is:
+    The constraint is:
     - (EV_gen * eff) / dem <= policy (where policy is a percentage giving max gen)
     - EV_gen <= dem * policy / eff
 

--- a/workflow/scripts/plot_statistics_sector.py
+++ b/workflow/scripts/plot_statistics_sector.py
@@ -275,6 +275,15 @@ def plot_transportation_production_timeseries(
         resample_fn=resample_fn,
         remove_sns_weights=remove_sns_weights,
     )
+
+    # This is cause of non-use issues with exisiting stock
+    small_negative_cols = df_all.columns[((df_all < 0) & (df_all > -0.0001)).any()]
+    large_negative_cols = df_all.columns[(df_all < -0.0001).any()]
+    if len(small_negative_cols) > 0 and len(large_negative_cols) == 0:
+        for col in small_negative_cols:
+            logger.warning(f"Negative values found in column '{col}', setting to zero")
+        df_all = df_all.clip(lower=0)
+
     df_veh = _filter_vehicle_type(df_all, vehicle)
 
     if df_veh.empty:
@@ -1492,12 +1501,12 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         snakemake = mock_snakemake(
             "plot_sector_production",
-            simpl="11",
+            simpl="12",
             opts="4h",
             clusters="4m",
             ll="v1.0",
             sector="E-G",
-            planning_horizons="2030",
+            planning_horizons="2018",
             interconnect="western",
         )
         rootpath = ".."

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -202,9 +202,8 @@ def apply_sector_constraints(n, config, global_snakemake):
         add_water_heater_constraints(n, config)
 
     # EV generation constraints
-    if config["sector"]["transport_sector"]["investment"]["ev_policy"]:
-        if not config["sector"]["transport_sector"]["investment"]["exogenous"]:
-            add_ev_generation_constraint(n, config, global_snakemake)
+    if config["sector"]["transport_sector"]["ev_policy"]:
+        add_ev_generation_constraint(n, config, global_snakemake)
 
     # Sector demand response constraints
     add_sector_demand_response_constraints(n, config)


### PR DESCRIPTION
Closes #625, #623, #618

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

In this PR I have made the following changes to the transport sector: 
- Ensured all EV loads from EFS have a profile. Before, if a vehicle mode was not used in EFS (ie. heavy duty trucks in 2030) the profile would be zero. In this case, I change it to a uniform load profile. 
- Removed exogenous road transportation investment from the model. Instead, all investment is endogenous and the user controls the allowable electrification per vehicle class per state per year. 
- Removed exogenous non-road investment from the model. This mimics the road transport, but everything still must be met by LPG right now. 
- Corrects the plotting issue, which had to do with existing links not being used, and instead being replaced with new links of the same technology. This turned out to just be that transport efficiencies can be quite sensitive
- Added charging values to the existing vehicle stock

The goal of this is to simplify the road transportation and remove a bunch of legacy logic from when it was first set up! There is still a little 'hacky' logic with the naming, but much easier to understand now imo. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
