### PR TITLE
`REM` for Sector Studies 

### DIFF
--- a/docs/source/config-wildcards.md
+++ b/docs/source/config-wildcards.md
@@ -75,10 +75,6 @@ The REM, SAFER, RPS can be defined using either the reeds zone name 'p##"
 the state code (eg, TX, CA, MT), pypsa-usa interconnect name (western, eastern, texas, usa),
 or nerc region name.
 
-```{warning}
-TCT Targets can only be used with renewable generators and utility scale batteries in sector studies.
-```
-
 There are currently:
 
 ```{eval-rst}

--- a/workflow/scripts/_helpers.py
+++ b/workflow/scripts/_helpers.py
@@ -498,16 +498,6 @@ def set_scenario_config(snakemake):
         update_config(snakemake.config, scenario_config[snakemake.wildcards.run])
 
 
-def update_config_with_sector_opts(config, sector_opts):
-    from packaging.version import parse
-    from snakemake.utils import update_config
-
-    for o in sector_opts.split("-"):
-        if o.startswith("CF+"):
-            l_ = o.split("+")[1:]
-            update_config(config, parse(l_))
-
-
 def get_opt(opts, expr, flags=None):
     """
     Return the first option matching the regular expression.

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -196,9 +196,8 @@ def extra_functionality(n, snapshots):
             add_water_heater_constraints(n, config)
 
         # EV generation constraints
-        if config["sector"]["transport_sector"]["investment"]["ev_policy"]:
-            if not config["sector"]["transport_sector"]["investment"]["exogenous"]:
-                add_ev_generation_constraint(n, config, global_snakemake)
+        if config["sector"]["transport_sector"].get("ev_policy", {}):
+            add_ev_generation_constraint(n, config, global_snakemake)
 
         # Sector demand response constraints
         add_sector_demand_response_constraints(n, config)

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -33,7 +33,6 @@ import yaml
 from _helpers import (
     configure_logging,
     update_config_from_wildcards,
-    update_config_with_sector_opts,
 )
 from opts.land import add_land_use_constraints
 from opts.policy import (
@@ -176,38 +175,33 @@ def extra_functionality(n, snapshots):
 
     # Apply sector-specific constraints if sector is enabled
     if sector_enabled:
-        apply_sector_constraints(n, config, global_snakemake)
+        # Heat pump constraints
+        add_cooling_heat_pump_constraints(n, config)
 
+        # Apply GSHP capacity constraint if urban/rural not split
+        if not config["sector"]["service_sector"].get("split_urban_rural", False):
+            add_gshp_capacity_constraint(n, config, global_snakemake)
 
-def apply_sector_constraints(n, config, global_snakemake):
-    """Apply all sector-specific constraints to the network."""
-    # Heat pump constraints
-    add_cooling_heat_pump_constraints(n, config)
+        # CO2 constraints for sectors
+        if "REMsec" in opts:
+            add_sector_co2_constraints(n, config)
 
-    # Apply GSHP capacity constraint if urban/rural not split
-    if not config["sector"]["service_sector"].get("split_urban_rural", False):
-        add_gshp_capacity_constraint(n, config, global_snakemake)
+        # Natural gas import/export constraints
+        if config["sector"]["natural_gas"].get("imports", False):
+            add_ng_import_export_limits(n, config)
 
-    # CO2 constraints for sectors
-    if config["sector"]["co2"].get("policy", {}):
-        add_sector_co2_constraints(n, config)
+        # Water heater constraints
+        water_config = config["sector"]["service_sector"].get("water_heating", {})
+        if not water_config.get("simple_storage", True):
+            add_water_heater_constraints(n, config)
 
-    # Natural gas import/export constraints
-    if config["sector"]["natural_gas"].get("imports", False):
-        add_ng_import_export_limits(n, config)
+        # EV generation constraints
+        if config["sector"]["transport_sector"]["investment"]["ev_policy"]:
+            if not config["sector"]["transport_sector"]["investment"]["exogenous"]:
+                add_ev_generation_constraint(n, config, global_snakemake)
 
-    # Water heater constraints
-    water_config = config["sector"]["service_sector"].get("water_heating", {})
-    if not water_config.get("simple_storage", True):
-        add_water_heater_constraints(n, config)
-
-    # EV generation constraints
-    if config["sector"]["transport_sector"]["investment"]["ev_policy"]:
-        if not config["sector"]["transport_sector"]["investment"]["exogenous"]:
-            add_ev_generation_constraint(n, config, global_snakemake)
-
-    # Sector demand response constraints
-    add_sector_demand_response_constraints(n, config)
+        # Sector demand response constraints
+        add_sector_demand_response_constraints(n, config)
 
 
 def run_optimize(n, rolling_horizon, skip_iterations, cf_solving, **kwargs):
@@ -362,31 +356,23 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "solve_network",
             interconnect="western",
-            simpl="75",
+            simpl="12",
             clusters="4m",
             ll="v1.0",
-            opts="12h",
+            opts="4h",
             sector="E-G",
-            planning_horizons="2030",
+            planning_horizons="2018",
         )
     configure_logging(snakemake)
     update_config_from_wildcards(snakemake.config, snakemake.wildcards)
-    if "sector_opts" in snakemake.wildcards.keys():
-        update_config_with_sector_opts(
-            snakemake.config,
-            snakemake.wildcards.sector_opts,
-        )
 
     opts = snakemake.wildcards.opts
-    if "sector_opts" in snakemake.wildcards.keys():
-        opts += "-" + snakemake.wildcards.sector_opts
     opts = [o for o in opts.split("-") if o != ""]
     solve_opts = snakemake.params.solving["options"]
 
     # sector specific co2 options
     if snakemake.wildcards.sector != "E":
-        # sector co2 limits applied via config file, not through Co2L
-        opts = [x for x in opts if not x.startswith("Co2L")]
+        opts = ["REMsec" if x == "REM" else x for x in opts]
         opts.append("sector")
 
     np.random.seed(solve_opts.get("seed", 123))


### PR DESCRIPTION
Closes #626 

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

In this PR I have: 
- Made the `REM` `opts` wildcard useable for sector studies. The underlying logic hasnt changed, just that the user now has to specify `REM` to apply emission limits (akin to how to trigger limits for the power sector)
- Moved the addition of sector constraints to the main loop (rather than in a nested function) as variables in the global namespace are used in the constraint addition. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.
