### PR TITLE
Checks for correct topological settings when using state level boundaries

### DIFF
--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -36,6 +36,9 @@ rule build_base_network:
     params:
         build_offshore_network=config_provider("offshore_network"),
         model_topology=config_provider("model_topology", "include"),
+        topological_boundaries=config_provider(
+            "model_topology", "topological_boundaries"
+        ),
         length_factor=config["lines"]["length_factor"],
     input:
         buses=DATA + "breakthrough_network/base_grid/bus.csv",

--- a/workflow/scripts/build_base_network.py
+++ b/workflow/scripts/build_base_network.py
@@ -589,6 +589,9 @@ def main(snakemake):
 
     # Filter Network to Only Specified Regions
     if model_topology is not None:
+        assert snakemake.params.topological_boundaries != "state", (
+            "State level filtering does not support regional filtering. See https://github.com/PyPSA/pypsa-usa/issues/662. "
+        )
         for region_type in model_topology:
             rm_buses = n.buses.loc[~(n.buses[f"{region_type}"].isin(model_topology[region_type]))]
             rm_lines = n.lines.loc[(n.lines.bus0.isin(rm_buses.index)) | (n.lines.bus1.isin(rm_buses.index))]


### PR DESCRIPTION
Closes #662

## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

Not a fix for #662, but just tells users that using the `model_topology.include` config options are not supported when `model_topology.topological_boundaries = "state"`. It directs users to the 662 ticket. 

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
