### PR TITLE
(Updated) Adding ReEDs bus-aggregated GODEEEP historical and climate data functionality to pypsa runs 

### DIFF
--- a/workflow/repo_data/config/config.default.yaml
+++ b/workflow/repo_data/config/config.default.yaml
@@ -19,7 +19,7 @@ foresight:  'perfect' # myopic, perfect
 
 model_topology:
   transmission_network: 'reeds' # [reeds, tamu]
-  topological_boundaries: 'reeds_zone' # [county, reeds_zone, state]
+  topological_boundaries: 'reeds_zone' # [county, reeds_zone]
   interface_transmission_limits: false
   include: # mixed zone types not supported
     # reeds_zone: []
@@ -34,11 +34,19 @@ model_topology:
 enable:
   build_cutout: false
 
+## implement wildcard for this, following interconnect example
 renewable_weather_years: [2019]
-
 snapshots:
   start: "2019-01-01"
-  end: "2020-01-01"
+  end: "2019-12-31"
+  inclusive: "left"
+
+## godeeep inputs for scenarios
+renewable_scenario_years: [2033]
+renewable_scenarios: ["rcp45hotter"] #["historical", "rcp45hotter", "rcp45cooler", "rcp85hotter", "rcp85cooler"]
+renewable_snapshots:
+  start: "2033-01-01" ## change the year to match renewable_scenario_years
+  end: "2033-12-31"
   inclusive: "left"
 
 # docs :
@@ -76,22 +84,6 @@ electricity:
     shift: 0
     marginal_cost: 999999
 
-  imports:
-    enable: false 
-    costs: wholesale # wholesale|carrier|float
-    co2_emissions: 0.428 
-    capacity_limit: true 
-    volume_limit: inf # 0 > x > 100 | 'inf'
-    balancing_period: month # day|week|month|year
-
-  exports:
-    enable: false 
-    costs: wholesale # wholesale|carrier|float
-    capacity_limit: true 
-    volume_limit: inf # 0 > x > 100 | 'inf'
-    balancing_period: month # day|week|month|year
-
-
 # docs :
 conventional:
   unit_commitment: false
@@ -108,30 +100,12 @@ lines:
   max_extension: 20000 #MW
   length_factor: 1.25
 
+
 # docs :
 links:
   p_max_pu: 1.0
   p_nom_max: .inf
   max_extension: 20000 #MW
-
-# docs :
-co2:
-  storage: false   # [false, true]
-  network:
-    enable: false   # [false, true]
-    capital_cost: 2736000   # in USD/12-inch diameter/mile
-    marginal_cost: 4   # in USD/tCO2
-    lifetime: 40   # in years
-    discount_rate: 0.07
-
-# docs :
-dac:
-  enable: false   # [false, true]
-  granularity: "node"   # ["node", "state", "nation"]
-  capital_cost: 6000000   # in USD/tCO2/h
-  electricity_input: 2.5   # in MWh/tCO2
-  lifetime: 20   # in years
-  discount_rate: 0.07
 
 # docs :
 costs:
@@ -286,14 +260,6 @@ solving:
   mem: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
   walltime: "12:00:00"
 
-walltime:
-  build_renewable_profiles: '04:00:00'
-  build_fuel_prices: '00:20:00'
-  add_demand: '02:00:00'
-  add_electricity: '04:00:00'
-  simplify_network: '05:00:00'
-  cluster_network: '04:00:00'
-  solve_network: '20:00:00'
 
 # docs :
 custom_files:

--- a/workflow/scripts/build_renewable_profiles.py
+++ b/workflow/scripts/build_renewable_profiles.py
@@ -17,6 +17,8 @@ from _helpers import configure_logging, get_snapshots
 from dask.distributed import Client
 from pypsa.geo import haversine
 from shapely.geometry import LineString
+from godeeep_helper import load_godeeep_data
+from zenodo_downloader import ZenodoScenarioDownloader
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +48,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "build_renewable_profiles",
             technology="solar",
-            interconnect="texas",
+            interconnect="western",
         )
     configure_logging(snakemake)
 
@@ -201,7 +203,46 @@ if __name__ == "__main__":
         return_capacity=True,
         **resource,
     )
+    if snakemake.params.renewable.get("dataset", False) == "godeeep":
+        logger.info("Loading godeeep renewable data...")
+        renewable_sns = get_snapshots(snakemake.config['renewable_snapshots'])
+        scenario = snakemake.config['renewable_scenarios'][0]
+        tech = snakemake.wildcards.technology
+        year = snakemake.config['renewable_scenario_years'][0]
+        ## loading profiles from local downloads
+        #profile = load_godeeep_data(snakemake.config['renewable_scenario_years'][0], snakemake.wildcards.technology, snakemake.config['renewable_scenarios'][0], renewable_sns)
+        ## loading profiles in from Zenodo
+        downloader = ZenodoScenarioDownloader()
+        if tech in ["onwind", "offwind", "offwind_floating"]:
+            tech = 'wind'
+            wind_height = '_100m'
+            start = ((year - 1980) // 20) * 20 + 1980
+            end = start + 19
+        elif tech == "solar":
+            wind_height = ''
+            technology = 'solar'
+            start = ((year - 2020) // 40) * 40 + 2020
+            end = start + 39
+        else:
+            raise ValueError("Invalid technology type. Choose 'onwind', 'offwind', 'offwind_floating' or 'solar'.")
+        
+        if scenario == "historical":
+            year_range = ''
+        else:
+            year_range = f'_{start}_{end}'
 
+        scenario_final = tech + wind_height + f'_{scenario}' + year_range
+        filename = f'{scenario_final}_{tech}_gen_cf_{year}{wind_height}_bus_mean.nc'
+        filepath = downloader.download_scenario_file(scenario_final, filename)
+        profile = xr.open_dataarray(filepath)
+
+        profile = profile.sel(time=renewable_sns) # filtering for appropriate time snapshot
+        ## changing bus format from int to float/string to match pypsa
+        bus_values = profile.bus.values
+        formatted_bus = [f"{float(bus):.1f}" for bus in bus_values]
+        profile = profile.assign_coords(bus=formatted_bus)
+
+    
     logger.info(f"Calculating maximal capacity per bus (method '{p_nom_max_meth}')")
     if p_nom_max_meth == "simple":
         p_nom_max = capacity_per_sqkm * availability @ area
@@ -232,13 +273,13 @@ if __name__ == "__main__":
 
     average_distance = xr.DataArray(average_distance, [buses])
     centre_of_mass = xr.DataArray(centre_of_mass, [buses, ("spatial", ["x", "y"])])
-
+    
     ds = xr.merge(
         [
             (correction_factor * profile).rename("profile"),
             capacities.rename("weight"),
             p_nom_max.rename("p_nom_max"),
-            potential.rename("potential"),
+            # potential.rename("potential"), # commenting out potential for now, not sure if needed but needs 'bus' dimension to join for godeeep dataset
             average_distance.rename("average_distance"),
         ],
     )
@@ -261,7 +302,7 @@ if __name__ == "__main__":
             & (ds["p_nom_max"] > params.get("min_p_nom_max", 0.0))
         ),
     )
-
+    
     if "clip_p_max_pu" in params:
         min_p_max_pu = params["clip_p_max_pu"]
         ds["profile"] = ds["profile"].where(ds["profile"] >= min_p_max_pu, 0)
@@ -269,3 +310,4 @@ if __name__ == "__main__":
     ds.to_netcdf(snakemake.output.profile)
     if client is not None:
         client.shutdown()
+

--- a/workflow/scripts/zenodo_downloader.py
+++ b/workflow/scripts/zenodo_downloader.py
@@ -1,0 +1,246 @@
+import requests
+import os
+from pathlib import Path
+import json
+
+class ZenodoScenarioDownloader:
+    
+    def __init__(self, download_dir="./data"):
+        self.download_dir = Path(download_dir)
+        self.download_dir.mkdir(exist_ok=True)
+        
+        # Mapping of scenarios to their Zenodo record IDs
+        self.scenario_records = {
+            "solar_historical": 17059209,  
+            "solar_rcp45hotter_2020_2059": 17069731,  
+            "solar_rcp45hotter_2060_2099": 17069758,
+            "solar_rcp45cooler_2020_2059": 17069655,  
+            "solar_rcp45cooler_2060_2099": 17069689, 
+            "solar_rcp85hotter_2020_2059": 17069842,  
+            "solar_rcp85hotter_2060_2099": 17069858,
+            "solar_rcp85cooler_2020_2059": 17069790, 
+            "solar_rcp85cooler_2060_2099": 17069818,
+            "wind_100m_historical": 17073578, 
+            "wind_100m_rcp45hotter_2020_2039": 17070280,
+            "wind_100m_rcp45hotter_2040_2059": 17070299,
+            "wind_100m_rcp45hotter_2060_2079": 17070334,
+            "wind_100m_rcp45hotter_2080_2099": 17070348,
+            "wind_100m_rcp45cooler_2020_2039": 17070385,
+            "wind_100m_rcp45cooler_2040_2059": 17070419,
+            "wind_100m_rcp45cooler_2060_2079": 17070459,
+            "wind_100m_rcp45cooler_2080_2099": 17070496,
+            "wind_100m_rcp85hotter_2020_2039": 17070534,
+            "wind_100m_rcp85hotter_2040_2059": 17070556,
+            "wind_100m_rcp85hotter_2060_2079": 17070591,
+            "wind_100m_rcp85hotter_2080_2099": 17070632,
+            "wind_100m_rcp85cooler_2020_2039": 17070655,
+            "wind_100m_rcp85cooler_2040_2059": 17070676,
+            "wind_100m_rcp85cooler_2060_2079": 17070717,
+            "wind_100m_rcp85cooler_2080_2099": 17070771
+        }
+        
+        # Cache for record metadata to avoid repeated API calls
+        self._metadata_cache = {}
+
+    def get_record_metadata(self, record_id):
+        """
+        Get metadata for a record (with caching)
+        """
+        if record_id in self._metadata_cache:
+            return self._metadata_cache[record_id]
+        
+        url = f"https://zenodo.org/api/records/{record_id}"
+        
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+            metadata = response.json()
+            self._metadata_cache[record_id] = metadata
+            return metadata
+            
+        except requests.exceptions.RequestException as e:
+            print(f"Failed to get metadata for record {record_id}: {e}")
+            return None
+
+    def download_scenario_file(self, scenario_name, filename, force_redownload=False):
+        """
+        Download a specific file from a scenario dataset
+        
+        Parameters:
+        - scenario_name: e.g., "solar_historical"
+        - filename: e.g., "solar_historical_solar_gen_cf_1980_bus_mean.nc"
+        - force_redownload: If True, redownload even if file exists
+        """
+        
+        # pointing file path to workflow/data/zenodo
+        (self.download_dir / "zenodo").mkdir(exist_ok=True) # create the zenodo directory if it doesn't exist
+        local_filepath = f"{self.download_dir}/zenodo/{filename}"
+        
+        # Check if file already exists
+        if Path(local_filepath).exists() and not force_redownload:
+            print(f"File {filename} already exists. Use force_redownload=True to redownload.")
+            return str(local_filepath)
+        
+        # Get the record ID for this scenario
+        record_id = self.scenario_records.get(scenario_name)
+        
+        if not record_id:
+            print(f"No record ID found for scenario: {scenario_name}")
+            print("Available scenarios with record IDs:")
+            for scenario, rec_id in self.scenario_records.items():
+                if rec_id is not None:
+                    print(f"  - {scenario} (ID: {rec_id})")
+            return None
+        
+        return self.download_by_record_id(record_id, filename, force_redownload)
+
+    def download_by_record_id(self, record_id, filename, force_redownload=False):
+        """
+        Download a file directly using a record ID
+        
+        Parameters:
+        - record_id: Zenodo record ID (e.g., 17059209)
+        - filename: Name of the file to download
+        - force_redownload: If True, redownload even if file exists
+        """
+        
+        # pointing file path to workflow/data/zenodo
+        local_filepath = f"{self.download_dir}/zenodo/{filename}"
+        
+        # Check if file already exists
+        if Path(local_filepath).exists() and not force_redownload:
+            print(f"File {filename} already exists. Use force_redownload=True to redownload.")
+            return str(local_filepath)
+        
+        # Get record metadata
+        metadata = self.get_record_metadata(record_id)
+        if not metadata:
+            return None
+        
+        # Find the specific file
+        target_file = None
+        for file_info in metadata.get('files', []):
+            if file_info['key'] == filename:
+                target_file = file_info
+                break
+        
+        if not target_file:
+            print(f"File '{filename}' not found in record {record_id}")
+            print("Available files:")
+            for file_info in metadata.get('files', []):
+                print(f"  - {file_info['key']}")
+            return None
+        
+        # Download the file
+        download_url = target_file['links']['self']
+        file_size_mb = target_file['size'] / (1024 * 1024)
+        
+        print(f"Downloading {filename} from record {record_id}...")
+        print(f"Size: {file_size_mb:.1f} MB")
+        print(f"Saving to: {local_filepath}")
+        
+        try:
+            response = requests.get(download_url, stream=True)
+            response.raise_for_status()
+            
+            total_size = int(response.headers.get('content-length', 0))
+            downloaded_size = 0
+            
+            with open(local_filepath, 'wb') as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+                        downloaded_size += len(chunk)
+                        
+                        # Show progress for large files
+                        if total_size > 10 * 1024 * 1024:  # Show progress for files > 10MB
+                            progress = (downloaded_size / total_size) * 100
+                            print(f"\rProgress: {progress:.1f}%", end="", flush=True)
+            
+            if total_size > 10 * 1024 * 1024:
+                print()  # New line after progress
+            
+            print(f"Successfully downloaded {filename}")
+            return str(local_filepath)
+            
+        except requests.exceptions.RequestException as e:
+            print(f"Download failed: {e}")
+            if Path(local_filepath).exists():
+                Path(local_filepath).unlink()  # Remove partial file
+            return None
+
+    def list_available_files(self, scenario_name):
+        """
+        List all available files in a scenario dataset
+        """
+        record_id = self.scenario_records.get(scenario_name)
+        if not record_id:
+            print(f"No record ID found for scenario: {scenario_name}")
+            print("Available scenarios with record IDs:")
+            for scenario, rec_id in self.scenario_records.items():
+                if rec_id is not None:
+                    print(f"  - {scenario} (ID: {rec_id})")
+            return []
+        
+        return self.list_files_by_record_id(record_id)
+
+    def list_files_by_record_id(self, record_id):
+        """
+        List all files in a record by record ID
+        """
+        metadata = self.get_record_metadata(record_id)
+        if not metadata:
+            return []
+        
+        files = []
+        record_title = metadata.get('metadata', {}).get('title', 'Unknown')
+        print(f"Available files in record {record_id} ({record_title}):")
+        
+        for file_info in metadata.get('files', []):
+            filename = file_info['key']
+            size_mb = file_info['size'] / (1024 * 1024)
+            files.append(filename)
+            print(f"  - {filename} ({size_mb:.1f} MB)")
+        
+        return files
+
+    def get_available_scenarios(self):
+        """
+        Get list of available scenarios (ones with record IDs)
+        """
+        available = []
+        print("Available scenarios:")
+        for scenario, record_id in self.scenario_records.items():
+            if record_id is not None:
+                available.append(scenario)
+                print(f"  - {scenario} (Record ID: {record_id})")
+        return available
+
+# Convenience functions
+def download_scenario_file(scenario_name, filename, download_dir="./data/zenodo"):
+    """
+    Quick function to download a single file from a scenario
+    
+    Example:
+    filepath = download_scenario_file("solar_historical", 
+                                    "solar_historical_solar_gen_cf_1980_bus_mean.nc")
+    """
+    downloader = ZenodoScenarioDownloader(download_dir)
+    return downloader.download_scenario_file(scenario_name, filename)
+
+def download_by_record_id(record_id, filename, download_dir="./data/zenodo"):
+    """
+    Quick function to download a file directly by record ID
+    
+    Example:
+    filepath = download_by_record_id(17059209, "solar_historical_solar_gen_cf_1980_bus_mean.nc")
+    """
+    downloader = ZenodoScenarioDownloader(download_dir)
+    return downloader.download_by_record_id(record_id, filename)
+
+def list_available_scenarios():
+    """
+    List all available scenarios
+    """
+    downloader = ZenodoScenarioDownloader()
+    return downloader.get_available_scenarios()


### PR DESCRIPTION
Closes #566 (sidequest).
Created new PR to replace #679 due to needed update to working branch

## Changes proposed in this Pull Request
- adding additional settings to config.default.yaml file to configure renewable weather year data in GODEEEP
- modified build_renewable_profiles.py to include "godeeep" option which uses capacity factors from the GODEEEP dataset (users can choose from a large range of historical years and future climate scenarios (1980-2099)
- created zenodo_downloader.py as a helper script to download the bus-aggregated netCDF files from Zenodo

## Checklist

- [ check] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
