### PR TITLE
blackdoc version update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
   - id: snakefmt
 
 - repo: https://github.com/keewis/blackdoc
-  rev: v0.4.1
+  rev: v0.4.4
   hooks:
   - id: blackdoc
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
<!--- Describe your changes in detail -->

Updates `blackdoc` in precommit. Not sure why this isnt caught in the auto-update. But the older version has started giving me the following error. 

```bash
blackdoc.................................................................Failed
- hook id: blackdoc
- exit code: 1

Traceback (most recent call last):
  File "/pc/clone/_WIuok-gTUSNwM7FrMWnRQ/py_env-python3/bin/blackdoc", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/pc/clone/_WIuok-gTUSNwM7FrMWnRQ/py_env-python3/lib/python3.12/site-packages/blackdoc/__main__.py", line 391, in main
    sys.exit(process(args))
             ^^^^^^^^^^^^^
  File "/pc/clone/_WIuok-gTUSNwM7FrMWnRQ/py_env-python3/lib/python3.12/site-packages/blackdoc/__main__.py", line 183, in process
    source: action(source.resolve(), mode, **action_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pc/clone/_WIuok-gTUSNwM7FrMWnRQ/py_env-python3/lib/python3.12/site-packages/blackdoc/__main__.py", line 35, in format_and_overwrite
    content, encoding, newline = black.decode_bytes(f.read())
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: decode_bytes() missing required argument 'mode' (pos 2)
```

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
