### PR TITLE
Fixes ERM for multi-horizon networks with perfect foresight.

### DIFF
--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -153,7 +153,7 @@ def extra_functionality(n, snapshots):
         ),
         "REM": lambda: add_regional_co2limit(n, config) if n.generators.p_nom_extendable.any() else None,
         "ERM": lambda: (
-            add_ERM_constraints(n, config, global_snakemake) if n.generators.p_nom_extendable.any() else None
+            add_ERM_constraints(n, snapshots, config, global_snakemake) if n.generators.p_nom_extendable.any() else None
         ),
         "TCT": lambda: (
             add_technology_capacity_target_constraints(n, config) if n.generators.p_nom_extendable.any() else None

--- a/workflow/scripts/test/fixtures/multi_period_prm.csv
+++ b/workflow/scripts/test/fixtures/multi_period_prm.csv
@@ -1,0 +1,3 @@
+name,region,prm,planning_horizon
+all_2030,all,0.15,2030
+all_2040,all,0.15,2040

--- a/workflow/scripts/test/test_reserves.py
+++ b/workflow/scripts/test/test_reserves.py
@@ -11,42 +11,14 @@ import numpy as np
 import pandas as pd
 import pytest
 from pypsa.descriptors import (
+    get_activity_mask,
+)
+from pypsa.descriptors import (
     get_switchable_as_dense as get_as_dense,
 )
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-from opts._helpers import get_region_buses
 from opts.reserves import add_ERM_constraints, store_ERM_duals
-
-
-@pytest.fixture
-def erm_config():
-    """Create a config dictionary with ERM settings."""
-    return {
-        "electricity": {
-            "SAFE_regional_reservemargins": os.path.join(os.path.dirname(__file__), "fixtures/test_prm.csv"),
-        },
-    }
-
-
-@pytest.fixture
-def erm_multi_region_config():
-    """Create a config dictionary with ERM settings for multiple regions and different reserve margins."""
-    return {
-        "electricity": {
-            "SAFE_regional_reservemargins": os.path.join(os.path.dirname(__file__), "fixtures/multi_region_prm.csv"),
-        },
-    }
-
-
-@pytest.fixture
-def erm_non_overlapping_config():
-    """Create a config dictionary with ERM settings for non-overlapping regions."""
-    return {
-        "electricity": {
-            "SAFE_regional_reservemargins": os.path.join(os.path.dirname(__file__), "fixtures/non_overlapping_erm.csv"),
-        },
-    }
 
 
 @pytest.fixture
@@ -59,7 +31,6 @@ def reserve_margin_network(base_network):
     n = base_network.copy()
 
     # Create a higher peak in load profile for reserve margin testing
-    # Make load profile peaky with peak at hour 11 for region 1 and hour 18 for region 2
     load_profile_region1 = pd.Series(
         np.concatenate([np.linspace(800, 1200, 12), np.linspace(1200, 800, 12)]),
         index=n.snapshots,
@@ -78,25 +49,52 @@ def reserve_margin_network(base_network):
     return n
 
 
-def test_erm_constraint_binding(reserve_margin_network, erm_config):
+@pytest.fixture
+def multi_period_reserve_network(multi_period_base_network):
+    """
+    Adapt multi-period base network for ERM constraint testing.
+
+    Extends the multi-period base network with peaky load profiles.
+    """
+    n = multi_period_base_network.copy()
+
+    load_profile_region1 = pd.Series(
+        np.tile(
+            np.concatenate([np.linspace(800, 1200, 12), np.linspace(1200, 800, 12)]),
+            2,  # two periods
+        ),
+        index=n.snapshots,
+    )
+
+    load_profile_region2 = pd.Series(
+        np.tile(
+            np.concatenate([np.linspace(500, 700, 18), np.linspace(700, 500, 6)]),
+            2,
+        ),
+        index=n.snapshots,
+    )
+
+    n.loads_t.p_set.loc[:, "load1"] = load_profile_region1
+    n.loads_t.p_set.loc[:, "load2"] = load_profile_region1 * 0.75
+    n.loads_t.p_set.loc[:, "load3"] = load_profile_region2
+
+    return n
+
+
+def test_erm_constraint_binding(reserve_margin_network):
     """Test that ERM constraint correctly limits generation capacity."""
     n = reserve_margin_network.copy()
 
-    # Read the PRM data from the CSV file
-    test_data = pd.read_csv(erm_config["electricity"]["SAFE_regional_reservemargins"])
+    prm_value = 0.90
 
-    # Set a high ERM requirement
-    test_data.loc[0, "prm"] = 0.90
-
-    # Run optimization with ERM constraints
     def extra_functionality(n, _):
-        add_ERM_constraints(n, regional_prm_data=test_data)
+        add_ERM_constraints(n, regional_prm_data={"all": prm_value})
 
     n.optimize(solver_name="glpk", multi_investment_periods=True, extra_functionality=extra_functionality)
     store_ERM_duals(n)
 
     nodal_demand = n.loads_t.p.T.groupby(n.loads.bus).sum().T
-    nodal_reserve_requirement = nodal_demand * (1.0 + test_data.loc[0, "prm"])
+    nodal_reserve_requirement = nodal_demand * (1.0 + prm_value)
 
     nodal_generator_capacity = (
         (n.generators.p_nom_opt * get_as_dense(n, "Generator", "p_max_pu", n.snapshots))
@@ -136,16 +134,14 @@ def test_erm_constraint_binding(reserve_margin_network, erm_config):
     )
 
 
-def test_multiple_non_overlapping_erms(reserve_margin_network, erm_non_overlapping_config):
+def test_multiple_non_overlapping_erms(reserve_margin_network):
     """Test that multiple ERM constraints work correctly for non-overlapping regions."""
     n = reserve_margin_network.copy()
 
-    # Read the PRM data from the CSV file
-    test_data = pd.read_csv(erm_non_overlapping_config["electricity"]["SAFE_regional_reservemargins"])
+    prm_dict = {"NERC1": 0.15, "NERC2": 0.30}
 
-    # Run optimization with multiple ERM constraints
     def extra_functionality(n, _):
-        add_ERM_constraints(n, regional_prm_data=test_data)
+        add_ERM_constraints(n, regional_prm_data=prm_dict)
 
     try:
         n.optimize(solver_name="glpk", multi_investment_periods=True, extra_functionality=extra_functionality)
@@ -154,91 +150,14 @@ def test_multiple_non_overlapping_erms(reserve_margin_network, erm_non_overlappi
 
     store_ERM_duals(n)
 
-    # Verify that ERM constraints were actually added (regardless of optimization success)
+    # Verify that ERM constraints were actually added
     erm_constraints = [c for c in n.model.constraints if "ERM" in c]
     assert len(erm_constraints) >= 2, f"Should have at least 2 ERM constraints, found {len(erm_constraints)}"
 
-    # Check that ERM constraints are satisfied for each region separately
-    for _, erm in test_data.iterrows():
-        # Get buses for this specific region
-        region_list = [region_.strip() for region_ in erm.region.split(",")]
-        region_buses = get_region_buses(n, region_list)
-
-        if region_buses.empty:
-            continue
-
-        # Calculate demand for this region
-        regional_demand = n.loads_t.p.groupby(n.loads.bus, axis=1).sum()
-        regional_demand = regional_demand.reindex(columns=region_buses.index, fill_value=0)
-        nodal_reserve_requirement = regional_demand * (1.0 + erm.prm)
-
-        # Calculate capacity for this region
-        region_gens = n.generators[n.generators.bus.isin(region_buses.index)]
-        region_storage = n.storage_units[n.storage_units.bus.isin(region_buses.index)]
-
-        # Generator capacity
-        if not region_gens.empty:
-            nodal_generator_capacity = (
-                (n.generators.p_nom_opt * get_as_dense(n, "Generator", "p_max_pu", n.snapshots))
-                .groupby(n.generators.bus, axis=1)
-                .sum()
-                .reindex(columns=region_buses.index, fill_value=0)
-            )
-        else:
-            nodal_generator_capacity = pd.DataFrame(0, index=n.snapshots, columns=region_buses.index)
-
-        # Storage capacity
-        if not region_storage.empty:
-            nodal_storage_capacity = (
-                (
-                    n.storage_units.p_nom_opt
-                    * get_as_dense(n, "StorageUnit", "p_max_pu", n.snapshots)
-                    * n.storage_units.efficiency_store
-                )
-                .groupby(n.storage_units.bus, axis=1)
-                .sum()
-                .reindex(columns=region_buses.index, fill_value=0)
-            )
-        else:
-            nodal_storage_capacity = pd.DataFrame(0, index=n.snapshots, columns=region_buses.index)
-
-        # Line contributions (only for lines within the region)
-        region_lines = n.lines[(n.lines.bus0.isin(region_buses.index)) & (n.lines.bus1.isin(region_buses.index))]
-        if not region_lines.empty and hasattr(n, "lines_t") and "s_reserves" in n.lines_t:
-            line_contribution = n.lines_t.s_reserves[region_lines.index]
-            injection_b0 = -1 * line_contribution.groupby(n.lines.loc[region_lines.index, "bus0"], axis=1).sum()
-            injection_b1 = line_contribution.groupby(n.lines.loc[region_lines.index, "bus1"], axis=1).sum()
-            line_injections = injection_b0.add(injection_b1, fill_value=0).reindex(
-                columns=region_buses.index,
-                fill_value=0,
-            )
-        else:
-            line_injections = pd.DataFrame(0, index=n.snapshots, columns=region_buses.index)
-
-        # Link contributions (only for links within the region)
-        region_links = n.links[(n.links.bus0.isin(region_buses.index)) & (n.links.bus1.isin(region_buses.index))]
-        if not region_links.empty and hasattr(n, "links_t") and "p_reserves" in n.links_t:
-            link_contribution = n.links_t.p_reserves[region_links.index]
-            injection_b0 = -1 * link_contribution.groupby(n.links.loc[region_links.index, "bus0"], axis=1).sum()
-            injection_b1 = link_contribution.groupby(n.links.loc[region_links.index, "bus1"], axis=1).sum()
-            link_injections = injection_b0.add(injection_b1, fill_value=0).reindex(
-                columns=region_buses.index,
-                fill_value=0,
-            )
-        else:
-            link_injections = pd.DataFrame(0, index=n.snapshots, columns=region_buses.index)
-
-        # Total reserve capacity for this region
-        nodal_reserve_capacity = (
-            nodal_generator_capacity.add(nodal_storage_capacity, fill_value=0)
-            .add(line_injections, fill_value=0)
-            .add(link_injections, fill_value=0)
-        )
-
-        # Check that reserve capacity meets requirement for this region
-        assert (nodal_reserve_capacity - nodal_reserve_requirement >= -0.1).all().all(), (
-            f"Regional reserve capacity for {erm.region} should be at least as large as the regional reserve requirement"
-        )
+    # Verify each region has its own ERM constraint
+    for region_name in prm_dict:
+        constraint_name = f"GlobalConstraint-{region_name}_ERM"
+        assert constraint_name in n.model.constraints, f"ERM constraint {constraint_name} should exist"
 
     # Verify that ERM duals are stored correctly
     assert hasattr(n.buses_t, "erm_price"), "ERM dual prices should be stored in n.buses_t.erm_price"
@@ -246,3 +165,178 @@ def test_multiple_non_overlapping_erms(reserve_margin_network, erm_non_overlappi
     # Check that we have ERM prices for both regions
     erm_price_data = n.buses_t.erm_price
     assert not erm_price_data.isnull().values.any(), "ERM price data should not contain any NaN values"
+
+
+def test_erm_increases_capacity(reserve_margin_network):
+    """Test that ERM constraint of 0.14 results in more capacity built than no ERM."""
+    # First run without ERM constraints
+    n_no_erm = reserve_margin_network.copy()
+    n_no_erm.optimize(solver_name="glpk", multi_investment_periods=True)
+
+    total_gen_capacity_no_erm = n_no_erm.generators.p_nom_opt.sum()
+    total_storage_capacity_no_erm = n_no_erm.storage_units.p_nom_opt.sum()
+    total_capacity_no_erm = total_gen_capacity_no_erm + total_storage_capacity_no_erm
+
+    # Now run with ERM constraint of 0.14
+    n_with_erm = reserve_margin_network.copy()
+
+    def extra_functionality(n, _):
+        add_ERM_constraints(n, regional_prm_data={"all": 0.14})
+
+    n_with_erm.optimize(
+        solver_name="glpk",
+        multi_investment_periods=True,
+        extra_functionality=extra_functionality,
+    )
+
+    total_gen_capacity_with_erm = n_with_erm.generators.p_nom_opt.sum()
+    total_storage_capacity_with_erm = n_with_erm.storage_units.p_nom_opt.sum()
+    total_capacity_with_erm = total_gen_capacity_with_erm + total_storage_capacity_with_erm
+
+    assert total_capacity_with_erm > total_capacity_no_erm, (
+        f"ERM constraint (prm=0.14) should result in more capacity built. "
+        f"Without ERM: {total_capacity_no_erm:.2f} MW, With ERM: {total_capacity_with_erm:.2f} MW"
+    )
+
+    assert n_with_erm.objective > n_no_erm.objective, (
+        f"ERM constraint should increase system cost. "
+        f"Without ERM: {n_no_erm.objective:.2f}, With ERM: {n_with_erm.objective:.2f}"
+    )
+
+
+def test_erm_increases_capacity_no_expandable_transmission(reserve_margin_network):
+    """Test that ERM constraint of 0.14 results in more capacity built than no ERM, with no expandable lines or links."""
+
+    def disable_transmission_expansion(n):
+        """Disable expansion of lines and links, and add firm generation at z2 for feasibility."""
+        n.lines["s_nom_extendable"] = False
+        n.links["p_nom_extendable"] = False
+        n.lines["s_nom"] = 2000
+        n.links["p_nom"] = 2000
+        n.add(
+            "Generator",
+            "gas_z2",
+            bus="z2",
+            p_nom=0,
+            p_nom_extendable=True,
+            carrier="gas",
+            capital_cost=500,
+            marginal_cost=20,
+            p_max_pu=1.0,
+            p_nom_max=5000,
+            build_year=2030,
+            lifetime=20,
+        )
+        return n
+
+    # First run without ERM constraints
+    n_no_erm = reserve_margin_network.copy()
+    n_no_erm = disable_transmission_expansion(n_no_erm)
+    n_no_erm.optimize(solver_name="glpk", multi_investment_periods=True)
+
+    total_gen_capacity_no_erm = n_no_erm.generators.p_nom_opt.sum()
+    total_storage_capacity_no_erm = n_no_erm.storage_units.p_nom_opt.sum()
+    total_capacity_no_erm = total_gen_capacity_no_erm + total_storage_capacity_no_erm
+
+    # Now run with ERM constraint of 0.14
+    n_with_erm = reserve_margin_network.copy()
+    n_with_erm = disable_transmission_expansion(n_with_erm)
+
+    def extra_functionality(n, _):
+        add_ERM_constraints(n, regional_prm_data={"all": 0.14})
+
+    n_with_erm.optimize(
+        solver_name="glpk",
+        multi_investment_periods=True,
+        extra_functionality=extra_functionality,
+    )
+
+    total_gen_capacity_with_erm = n_with_erm.generators.p_nom_opt.sum()
+    total_storage_capacity_with_erm = n_with_erm.storage_units.p_nom_opt.sum()
+    total_capacity_with_erm = total_gen_capacity_with_erm + total_storage_capacity_with_erm
+
+    assert total_capacity_with_erm > total_capacity_no_erm, (
+        f"ERM constraint (prm=0.14) should result in more capacity built (no expandable transmission). "
+        f"Without ERM: {total_capacity_no_erm:.2f} MW, With ERM: {total_capacity_with_erm:.2f} MW"
+    )
+
+    assert n_with_erm.objective > n_no_erm.objective, (
+        f"ERM constraint should increase system cost (no expandable transmission). "
+        f"Without ERM: {n_no_erm.objective:.2f}, With ERM: {n_with_erm.objective:.2f}"
+    )
+
+
+def test_multi_period_erm_optimization(multi_period_reserve_network):
+    """Test that multi-period network with ERM solves and creates one constraint (not per period)."""
+    n = multi_period_reserve_network.copy()
+
+    prm_dict = {"all": 0.15}
+
+    def extra_functionality(n, _):
+        add_ERM_constraints(n, regional_prm_data=prm_dict)
+
+    n.optimize(solver_name="glpk", multi_investment_periods=True, extra_functionality=extra_functionality)
+
+    # Verify one ERM constraint is created (not two per period)
+    erm_constraints = [c for c in n.model.constraints if "ERM" in c]
+    assert len(erm_constraints) == 1, (
+        f"Should have exactly 1 ERM constraint, found {len(erm_constraints)}: {erm_constraints}"
+    )
+    assert "GlobalConstraint-all_ERM" in n.model.constraints
+
+
+def test_multi_period_erm_increases_capacity(multi_period_reserve_network):
+    """Test that ERM increases capacity across multiple investment periods."""
+    # Without ERM
+    n_no_erm = multi_period_reserve_network.copy()
+    n_no_erm.optimize(solver_name="glpk", multi_investment_periods=True)
+
+    total_capacity_no_erm = n_no_erm.generators.p_nom_opt.sum() + n_no_erm.storage_units.p_nom_opt.sum()
+
+    # With ERM
+    n_with_erm = multi_period_reserve_network.copy()
+
+    def extra_functionality(n, _):
+        add_ERM_constraints(n, regional_prm_data={"all": 0.15})
+
+    n_with_erm.optimize(
+        solver_name="glpk",
+        multi_investment_periods=True,
+        extra_functionality=extra_functionality,
+    )
+
+    total_capacity_with_erm = n_with_erm.generators.p_nom_opt.sum() + n_with_erm.storage_units.p_nom_opt.sum()
+
+    assert total_capacity_with_erm > total_capacity_no_erm, (
+        f"ERM should increase capacity in multi-period. "
+        f"Without: {total_capacity_no_erm:.2f}, With: {total_capacity_with_erm:.2f}"
+    )
+
+
+def test_multi_period_erm_activity_masking(multi_period_reserve_network):
+    """Verify that retiring generators don't contribute to reserves in periods after retirement."""
+    n = multi_period_reserve_network.copy()
+
+    # Confirm gas_retiring is in the network and has the expected lifetime
+    assert "gas_retiring" in n.generators.index
+    assert n.generators.loc["gas_retiring", "build_year"] == 2025
+    assert n.generators.loc["gas_retiring", "lifetime"] == 10
+
+    # Check activity mask: gas_retiring should be active in 2030 but not in 2040
+    activity = get_activity_mask(n, "Generator", n.snapshots)
+    period_2030_mask = n.snapshots.get_level_values(0) == 2030
+    period_2040_mask = n.snapshots.get_level_values(0) == 2040
+
+    assert activity.loc[period_2030_mask, "gas_retiring"].all(), "gas_retiring should be active in all 2030 snapshots"
+    assert not activity.loc[period_2040_mask, "gas_retiring"].any(), (
+        "gas_retiring should be inactive in all 2040 snapshots"
+    )
+
+    # Run optimization with ERM
+    def extra_functionality(n, _):
+        add_ERM_constraints(n, regional_prm_data={"all": 0.15})
+
+    n.optimize(solver_name="glpk", multi_investment_periods=True, extra_functionality=extra_functionality)
+
+    # Verify the constraint was added successfully
+    assert "GlobalConstraint-all_ERM" in n.model.constraints


### PR DESCRIPTION
- Fixes issue introduced in #705 which caused unbounded variable when no-extendable links are  enabled
- Extends refactor to now work with multi-horizon networks with perfect foresight
- Issue still exists with myopic foresight solution, but likely not due to ERM, needs further investigation.