### PR TITLE
egs USA wide handling

### DIFF
--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -225,7 +225,7 @@ rule build_renewable_profiles:
         mem_mb=lambda wildcards, input, attempt: (
             ATLITE_NPROCESSES * input.size // 2000000
         )
-        * 1.5,
+        * 2.5,
         walltime=config_provider(
             "walltime", "build_renewable_profiles", default="02:30:00"
         ),
@@ -880,7 +880,7 @@ rule prepare_network:
     threads: 1
     resources:
         walltime=config_provider("walltime", "prepare_network", default="00:30:00"),
-        mem_mb=lambda wildcards, input, attempt: (input.size // 100000) * attempt * 2,
+        mem_mb=lambda wildcards, input, attempt: (input.size // 100000) * attempt * 6,
     group:
         "prepare"
     log:

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -357,13 +357,19 @@ def filter_plants_by_region(
             right_on="ba",
             how="left",
         )
-        plants_must_add = plants_no_region_all_shapes[
-            plants_no_region_all_shapes.interconnect != plants_no_region_all_shapes.interconnection
-        ]
+        # Handles non-US wide interconnection cases (western, eastern, texas)
+        if "interconnection" in plants_no_region_all_shapes.columns:
+            plants_must_add = plants_no_region_all_shapes[
+                plants_no_region_all_shapes.interconnect != plants_no_region_all_shapes.interconnection
+            ]
+            remaining_plants = plants_no_region_all_shapes[
+                plants_no_region_all_shapes.interconnect == plants_no_region_all_shapes.interconnection
+            ]
+        # Handles US wide interconnection cases
+        else:
+            plants_must_add = plants_no_region_all_shapes
+            remaining_plants = pd.DataFrame()
         plants_must_add.set_index("generator_name", inplace=True)
-        remaining_plants = plants_no_region_all_shapes[
-            plants_no_region_all_shapes.interconnect == plants_no_region_all_shapes.interconnection
-        ]
 
         if not remaining_plants.empty:
             remaining_clean = remaining_plants.drop(columns=["index_right"], errors="ignore")

--- a/workflow/scripts/retrieve_egs.py
+++ b/workflow/scripts/retrieve_egs.py
@@ -13,13 +13,21 @@ logger = logging.getLogger(__name__)
 
 
 def download_egs_repository(interconnect, dispatch, subdir):
+    # Map interconnects that don't have specific files to use 'usa'
+    interconnect_mapping = {
+        "eastern": "usa",
+        # texas, western, and usa use their own files
+    }
+    
+    interconnect_to_use = interconnect_mapping.get(interconnect, interconnect)
+    
     # Save locations
-    url = f"https://zenodo.org/records/14221666/files/{interconnect}_7km_{dispatch}.zip"
-
-    tarball_fn = Path(f"{rootpath}/EGS_{interconnect}_{dispatch}.zip")
+    url = f"https://zenodo.org/records/14221666/files/{interconnect_to_use}_7km_{dispatch}.zip"
+    
+    tarball_fn = Path(f"{rootpath}/EGS_{interconnect_to_use}_{dispatch}.zip")
     to_fn = Path(f"{rootpath}/{subdir}")
-
-    logger.info(f"Downloading EGS zenodo repository from '{url}'.")
+    
+    logger.info(f"Downloading EGS zenodo repository from '{url}' (mapped from interconnect '{interconnect}').")
     progress_retrieve(url, tarball_fn)
 
     logger.info(f"Extracting {dispatch} EGS databundle.")

--- a/workflow/scripts/retrieve_egs.py
+++ b/workflow/scripts/retrieve_egs.py
@@ -18,15 +18,15 @@ def download_egs_repository(interconnect, dispatch, subdir):
         "eastern": "usa",
         # texas, western, and usa use their own files
     }
-    
+
     interconnect_to_use = interconnect_mapping.get(interconnect, interconnect)
-    
+
     # Save locations
     url = f"https://zenodo.org/records/14221666/files/{interconnect_to_use}_7km_{dispatch}.zip"
-    
+
     tarball_fn = Path(f"{rootpath}/EGS_{interconnect_to_use}_{dispatch}.zip")
     to_fn = Path(f"{rootpath}/{subdir}")
-    
+
     logger.info(f"Downloading EGS zenodo repository from '{url}' (mapped from interconnect '{interconnect}').")
     progress_retrieve(url, tarball_fn)
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
<!--- Handles modelling EGS USA wide by using the USA EGS dataset for the eastern interconnect when only the east to specified. 

Increases memory for build_renewable_profiles too. -->

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
