### PR TITLE
Adds UCAP derating for thermal plants

### DIFF
--- a/workflow/repo_data/config/config.common.yaml
+++ b/workflow/repo_data/config/config.common.yaml
@@ -153,3 +153,16 @@ offshore_shape:
 
 offshore_network:
   bus_spacing: 25000 # km
+
+# docs :
+# UCAP (Unforced Capacity) calculation based on Forced Outage Rates (FOR)
+# UCAP = ICAP * (1 - FOR), applied as p_max_pu = 1 - FOR for conventional generators
+ucap:
+  enable: false  # [false, true]
+  forced_outage_rates:  # Forced outage rates in percent
+    coal: 11.061
+    oil: 11.061
+    hydro: 8.127
+    CCGT: 6.107
+    nuclear: 2.207
+    OCGT: 6.259

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -599,7 +599,6 @@ def dynamic_fuel_price_files(wildcards):
 rule build_powerplants:
     params:
         pudl_path=config_provider("pudl_path"),
-        renewable_weather_year=config_provider("renewable_weather_years"),
     input:
         wecc_ads="repo_data/WECC_ADS_public",
         eia_ads_generator_mapping="repo_data/WECC_ADS_public/eia_ads_generator_mapping_updated.csv",

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -833,6 +833,7 @@ rule add_extra_components:
             "model_topology", "topological_boundaries"
         ),
         transmission_network=config_provider("model_topology", "transmission_network"),
+        ucap=config_provider("ucap", default={}),
     output:
         RESOURCES + "{interconnect}/elec_s{simpl}_c{clusters}_ec.nc",
     log:

--- a/workflow/scripts/add_extra_components.py
+++ b/workflow/scripts/add_extra_components.py
@@ -1367,6 +1367,54 @@ def add_co2_network(n: pypsa.Network, config: dict):
     )
 
 
+def apply_ucap(n: pypsa.Network, ucap_config: dict) -> None:
+    """
+    Apply UCAP (Unforced Capacity) derating to conventional generators.
+
+    Sets p_max_pu = 1 - FOR (Forced Outage Rate) for each carrier specified
+    in the configuration. This converts ICAP to UCAP using the formula:
+    UCAP = ICAP * (1 - FOR)
+
+    For generators with time-varying p_max_pu values in n.generators_t.p_max_pu,
+    the time series is multiplied by (1 - FOR).
+
+    Arguments:
+        n: pypsa.Network
+        ucap_config: dict with 'enable' boolean and 'forced_outage_rates' dict
+            mapping carrier names to FOR values in percent
+    """
+    if not ucap_config.get("enable", False):
+        return
+
+    forced_outage_rates = ucap_config.get("forced_outage_rates", {})
+    if not forced_outage_rates:
+        logger.warning("UCAP enabled but no forced_outage_rates defined")
+        return
+
+    for carrier, for_pct in forced_outage_rates.items():
+        ucap_factor = 1 - (for_pct / 100)
+        mask = n.generators["carrier"] == carrier
+        if not mask.any():
+            logger.debug(f"No generators found for carrier {carrier} when applying UCAP")
+            continue
+
+        gen_names = n.generators.index[mask]
+
+        # Apply to static p_max_pu
+        n.generators.loc[mask, "p_max_pu"] *= ucap_factor
+
+        # Apply to time-varying p_max_pu if present
+        gens_with_time_varying = [g for g in gen_names if g in n.generators_t.p_max_pu.columns]
+        if gens_with_time_varying:
+            n.generators_t.p_max_pu[gens_with_time_varying] *= ucap_factor
+            logger.info(
+                f"Applied UCAP derating to {carrier}: factor = {ucap_factor:.4f} (FOR = {for_pct}%) "
+                f"[{len(gen_names)} static, {len(gens_with_time_varying)} time-varying]",
+            )
+        else:
+            logger.info(f"Applied UCAP derating to {carrier}: factor = {ucap_factor:.4f} (FOR = {for_pct}%)")
+
+
 def add_dac(n: pypsa.Network, config: dict, sector: bool):
     """Adds node level DAC capabilities."""
     # generate node level buses to represent emitted, captured and accounted CO2 and links to represent DAC in function of whether network is based on sectors or not
@@ -1691,6 +1739,12 @@ if __name__ == "__main__":
                 logger.warning(
                     "Not adding DAC capabilities given that CO2 (underground) storage is not enabled",
                 )
+
+    # Apply UCAP derating to conventional generators
+    ucap_config = snakemake.config.get("ucap", {})
+    if ucap_config.get("enable", False):
+        logger.info("Applying UCAP derating to conventional generators")
+        apply_ucap(n, ucap_config)
 
     n.consistency_check()
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))

--- a/workflow/scripts/build_powerplants.py
+++ b/workflow/scripts/build_powerplants.py
@@ -690,9 +690,7 @@ if __name__ == "__main__":
         rootpath = "."
     configure_logging(snakemake)
 
-    weather_year = snakemake.params.renewable_weather_year[0]
-    # Cap the year at 2023 if it's greater
-    data_year = min(int(weather_year), 2023)
+    data_year = 2023  # Use latest available PUDL data
     start_date = f"{data_year}-01-01"
     end_date = f"{data_year + 1}-01-01"
 

--- a/workflow/scripts/opts/reserves.py
+++ b/workflow/scripts/opts/reserves.py
@@ -279,6 +279,7 @@ def define_erm_nodal_balance_constraints(n, snapshots, erm, region_name, region_
     ]
 
     exprs = []
+
     for c, attr, column, sign, activity in args:
         if n.df(c).empty:
             continue
@@ -287,7 +288,13 @@ def define_erm_nodal_balance_constraints(n, snapshots, erm, region_name, region_
             sign = sign * n.df(c).sign
 
         expr = DataArray(sign) * m[f"{c}-{attr}"]
-        cbuses = n.df(c)[column][lambda ds: ds.isin(buses)].rename("Bus")
+        df = n.df(c)
+        # For components with both bus0 and bus1, require both to be in buses
+        if "bus0" in df.columns and "bus1" in df.columns:
+            mask = df["bus0"].isin(buses) & df["bus1"].isin(buses)
+            cbuses = df.loc[mask, column].rename("Bus")
+        else:
+            cbuses = df[column][lambda ds: ds.isin(buses)].rename("Bus")
 
         expr = expr.sel({c: cbuses.index})
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
- Adds Unforced Capacity derating option for thermal plants
- Updates the ERM Reserve Margin constraint to prevent reserve sharing across planning regions

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
