### PR TITLE
Per-carrier ATB scenario overrides; export full scenario grid

### DIFF
--- a/docs/source/configtables/costs.csv
+++ b/docs/source/configtables/costs.csv
@@ -1,4 +1,10 @@
 ,Unit,Values,Description
+atb,,,"NREL ATB scenario selection. ATB carries every (scenario, model_case) for each carrier — these settings choose which slice ``load_costs`` uses."
+-- scenario,--,``Moderate`` \| ``Advanced`` \| ``Conservative``,"Global default ATB cost trajectory. ``Advanced`` = optimistic / fastest cost decline; ``Conservative`` = pessimistic. See :ref:`data-costs`."
+-- model_case,--,``Market`` \| ``R&D``,"Global default. ``Market`` bakes current policy incentives (PTC/ITC) into financing; ``R&D`` strips them out for a pure-learning view."
+-- overrides,,Mapping,"Optional per-carrier overrides. Keys are pypsa-names (``solar``, ``onwind``, ``nuclear``, ``CCGT``, ``4hr_battery_storage``, …); each value may set ``scenario`` and/or ``model_case``. Anything unset falls back to the global default."
+aeo,,,"EIA AEO fuel-cost scenario."
+-- scenario,--,``reference`` \| ``high`` \| ``low``,"AEO case used to fetch projected fuel costs for the requested year."
 social_discount_rate,--,float; e.g. ``0.02``,"Discount rate used for weighting multi-investment objective function values."
 version,--,vX.X.X; e.g. ``v0.5.0``,"Version of `technology-data` repository to use."
 rooftop_share,--,float,"Share of rooftop PV when calculating capital cost of solar (joint rooftop and utility-scale PV)."

--- a/docs/source/data-costs.md
+++ b/docs/source/data-costs.md
@@ -2,13 +2,53 @@
 # Costs
 ## Costs and Candidate Resources
 
- In PyPSA-USA, candidate resource forecasted capital and operating costs are defined by the NREL Annual Technology Baseline (ATB) accessed through the PUDL project. The model currently uses the 2024 ATB which provides data for expected costs across the years 2025 - 2050. Users are able to configure which ATB model case and scenario to reference:
+ In PyPSA-USA, candidate resource forecasted capital and operating costs are defined by the NREL Annual Technology Baseline (ATB) accessed through the PUDL project. The model currently uses the 2024 ATB which provides data for expected costs across the years 2025 - 2050. The full ATB scenario grid is exported by `build_cost_data` for every planning horizon, and the configuration below selects which slice of that grid each carrier ultimately uses.
 
- ```yaml
-   atb:
-    model_case: "Market" # Market, R&D
-    scenario: "Moderate" # Advanced, Conservative, Moderate
+### Selecting an ATB scenario and model case
+
+ATB exposes two orthogonal axes that bound the cost trajectory of every technology:
+
+- **`scenario`** — `Moderate` (default), `Advanced`, or `Conservative`. Reflects how aggressively technology costs decline over time. `Advanced` is most optimistic; `Conservative` is most pessimistic.
+- **`model_case`** — `Market` (default) or `R&D`. `Market` bakes current policy incentives (PTC/ITC) into the financing assumptions; `R&D` strips those out and isolates pure technology learning.
+
+The global default applies to every carrier unless an override is set:
+
+```yaml
+costs:
+  atb:
+    model_case: "Market"   # Market, R&D
+    scenario: "Moderate"   # Moderate, Advanced, Conservative
 ```
+
+#### Per-carrier overrides
+
+To stress-test specific carriers under a different scenario without touching the global default, add an `overrides` block keyed by the carrier's pypsa-name. Either field can be set independently — anything left out falls back to the global default:
+
+```yaml
+costs:
+  atb:
+    model_case: "Market"
+    scenario: "Moderate"
+    overrides:
+      solar:
+        scenario: "Advanced"            # cheaper solar
+      onwind:
+        scenario: "Advanced"
+        model_case: "R&D"               # no-PTC view of onshore wind
+      nuclear:
+        scenario: "Conservative"        # higher-cost nuclear
+```
+
+Resolution order, highest priority first:
+1. Per-carrier override under `costs.atb.overrides[<pypsa-name>]`
+2. Global `costs.atb.scenario` / `costs.atb.model_case`
+3. Hardcoded fallback (`Moderate` / `Market`)
+
+Carrier names must match the keys in `ATB_TECH_MAPPER` (`workflow/scripts/constants.py`) — e.g. `solar`, `onwind`, `offwind`, `offwind_floating`, `nuclear`, `SMR`, `CCGT`, `CCGT-95CCS`, `coal`, `coal-95CCS`, `geothermal`, `biomass`, `4hr_battery_storage`, etc.
+
+#### How selection happens
+
+`build_cost_data` writes one row per `(pypsa-name, parameter, atb_scenario, atb_model_case)` into `resources/costs/costs_{year}.csv`, so every ATB combination is available without rerunning the rule. Scenario-independent rows (EGS supply curves, transmission costs, emissions factors) carry `NA` in the scenario columns and apply universally. The `load_costs` helper in `_helpers.py` reads the config and selects the right row per carrier before pivoting, so changing `costs.atb` only requires re-running the downstream rules — not `build_cost_data`.
 
 To reflect regional differences, capital costs are adjusted using [EIA state-level CapEx multipliers](https://www.eia.gov/analysis/studies/powerplants/capitalcost/pdf/capital_cost_AEO2020.pdf).
 

--- a/workflow/repo_data/config/config.default.yaml
+++ b/workflow/repo_data/config/config.default.yaml
@@ -157,6 +157,12 @@ costs:
   atb:
     model_case: "Market" # Market, R&D
     scenario: "Moderate" # Advanced, Conservative, Moderate
+    overrides: # Optional per-carrier overrides for scenario and/or model_case. Falls back to defaults above when unset.
+      # solar:
+      #   scenario: "Advanced"
+      # nuclear:
+      #   scenario: "Conservative"
+      #   model_case: "R&D"
   aeo:
     scenario: "reference" # reference, high, low
   social_discount_rate: 0.02

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -833,6 +833,7 @@ rule add_extra_components:
             "model_topology", "topological_boundaries"
         ),
         transmission_network=config_provider("model_topology", "transmission_network"),
+        costs=config_provider("costs"),
     output:
         RESOURCES + "{interconnect}/elec_s{simpl}_c{clusters}_ec.nc",
     log:

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -100,7 +100,7 @@ rule build_bus_regions:
 
 rule build_cost_data:
     params:
-        costs=config_provider("costs"),
+        aeo=config_provider("costs", "aeo"),
         pudl_path=config_provider("pudl_path"),
     input:
         efs_tech_costs="repo_data/costs/EFS_Technology_Data.xlsx",

--- a/workflow/scripts/_helpers.py
+++ b/workflow/scripts/_helpers.py
@@ -153,9 +153,46 @@ def calculate_annuity(n, r):
         return 1 / n
 
 
-def load_costs(tech_costs: str) -> pd.DataFrame:
+def load_costs(tech_costs: str, costs_config: dict | None = None) -> pd.DataFrame:
+    """Load tech costs and select the configured ATB scenario/model_case per carrier.
+
+    The CSV emitted by ``build_cost_data`` carries every (atb_scenario, atb_model_case)
+    combination plus scenario-independent rows (EGS, sector_costs CSVs) where those
+    columns are NA. ``costs_config["atb"]`` provides global defaults
+    (``scenario``, ``model_case``) and an optional per-carrier ``overrides`` map. If the
+    file predates these columns or no config is supplied, the data is pivoted as-is.
+    """
     df = pd.read_csv(tech_costs)
-    return df.pivot(index="pypsa-name", columns="parameter", values="value").fillna(0)
+
+    if "atb_scenario" not in df.columns or "atb_model_case" not in df.columns:
+        return df.pivot(index="pypsa-name", columns="parameter", values="value").fillna(0)
+
+    atb_cfg = (costs_config or {}).get("atb") or {}
+    default_scenario = atb_cfg.get("scenario", "Moderate")
+    default_case = atb_cfg.get("model_case", "Market")
+    overrides = atb_cfg.get("overrides") or {}
+
+    has_scenario = df["atb_scenario"].notna() & df["atb_model_case"].notna()
+    atb_rows = df[has_scenario].copy()
+    static_rows = df[~has_scenario].copy()
+
+    carriers = atb_rows["pypsa-name"].unique()
+    scenario_map = {c: (overrides.get(c) or {}).get("scenario", default_scenario) for c in carriers}
+    case_map = {c: (overrides.get(c) or {}).get("model_case", default_case) for c in carriers}
+    selected = atb_rows[
+        (atb_rows["atb_scenario"] == atb_rows["pypsa-name"].map(scenario_map))
+        & (atb_rows["atb_model_case"] == atb_rows["pypsa-name"].map(case_map))
+    ]
+
+    combined = pd.concat(
+        [
+            selected[["pypsa-name", "parameter", "value"]],
+            static_rows[["pypsa-name", "parameter", "value"]],
+        ],
+        ignore_index=True,
+    )
+    combined = combined.drop_duplicates(subset=["pypsa-name", "parameter"], keep="first")
+    return combined.pivot(index="pypsa-name", columns="parameter", values="value").fillna(0)
 
 
 def load_network_for_plots(fn, tech_costs, config, combine_hydro_ps=True):

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -19,6 +19,7 @@ from _helpers import (
     calculate_annuity,
     configure_logging,
     export_network_for_gis_mapping,
+    load_costs,
     update_p_nom_max,
     weighted_avg,
 )
@@ -1034,8 +1035,7 @@ def main(snakemake):
     all_reeds_shapes = gpd.read_file(snakemake.input.all_reeds_shapes)
     reeds_memberships = pd.read_csv(snakemake.input.reeds_memberships)
 
-    costs = pd.read_csv(snakemake.input.tech_costs)
-    costs = costs.pivot(index="pypsa-name", columns="parameter", values="value")
+    costs = load_costs(snakemake.input.tech_costs, params.costs)
     update_transmission_costs(n, costs, params.length_factor)
 
     renewable_carriers = set(params.renewable_carriers)

--- a/workflow/scripts/add_extra_components.py
+++ b/workflow/scripts/add_extra_components.py
@@ -6,7 +6,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pypsa
-from _helpers import calculate_annuity, configure_logging
+from _helpers import calculate_annuity, configure_logging, load_costs
 from add_electricity import add_missing_carriers
 from eia import FuelCosts
 from opts._helpers import get_region_buses
@@ -1499,10 +1499,9 @@ if __name__ == "__main__":
     elec_config = snakemake.config["electricity"]
 
     costs_dict = {
-        n.investment_periods[i]: pd.read_csv(snakemake.input.tech_costs[i]).pivot(
-            index="pypsa-name",
-            columns="parameter",
-            values="value",
+        n.investment_periods[i]: load_costs(
+            snakemake.input.tech_costs[i],
+            snakemake.params.costs,
         )
         for i in range(len(n.investment_periods))
     }

--- a/workflow/scripts/build_cost_data.py
+++ b/workflow/scripts/build_cost_data.py
@@ -459,9 +459,7 @@ if __name__ == "__main__":
     else:
         rootpath = "."
 
-    costs = snakemake.params.costs
-    atb_params = costs.get("atb") or {}
-    aeo_params = costs.get("aeo") or {}
+    aeo_params = snakemake.params.aeo or {}
 
     tech_year = snakemake.wildcards.year
     if int(tech_year) < 2024:

--- a/workflow/scripts/build_cost_data.py
+++ b/workflow/scripts/build_cost_data.py
@@ -221,166 +221,69 @@ def get_sector_costs(
     return final
 
 
-if __name__ == "__main__":
-    if "snakemake" not in globals():
-        from _helpers import mock_snakemake
+# Transmission cost assumptions are independent of ATB scenario / model case.
+# TEPCC 2023; WACC & Lifetime from https://emp.lbl.gov/publications/improving-estimates-transmission
+# Subsea: Purvins et al. (2018): https://doi.org/10.1016/j.jclepro.2018.03.095
+TRANSMISSION_DATA = [
+    {"pypsa-name": "HVAC overhead", "parameter": "capex_per_mw_km", "value": 1541},
+    {
+        "pypsa-name": "HVAC overhead",
+        "parameter": "cost_recovery_period_years",
+        "value": 60,
+    },
+    {"pypsa-name": "HVAC overhead", "parameter": "wacc_real", "value": 0.044},
+    {"pypsa-name": "HVDC overhead", "parameter": "capex_per_mw_km", "value": 1026.53},
+    {
+        "pypsa-name": "HVDC overhead",
+        "parameter": "cost_recovery_period_years",
+        "value": 60,
+    },
+    {"pypsa-name": "HVDC overhead", "parameter": "wacc_real", "value": 0.044},
+    {"pypsa-name": "HVDC submarine", "parameter": "capex_per_mw_km", "value": 504.141},
+    {
+        "pypsa-name": "HVDC submarine",
+        "parameter": "cost_recovery_period_years",
+        "value": 60,
+    },
+    {"pypsa-name": "HVDC submarine", "parameter": "wacc_real", "value": 0.044},
+    {
+        "pypsa-name": "HVDC inverter pair",
+        "parameter": "capex_per_kw",
+        "value": 173.730,
+    },
+    {
+        "pypsa-name": "HVDC inverter pair",
+        "parameter": "cost_recovery_period_years",
+        "value": 60,
+    },
+    {"pypsa-name": "HVDC inverter pair", "parameter": "wacc_real", "value": 0.044},
+]
 
-        snakemake = mock_snakemake("build_cost_data", year=2030)
-        rootpath = ".."
-    else:
-        rootpath = "."
 
-    costs = snakemake.params.costs
-    atb_params = costs.get("atb")
-    aeo_params = costs.get("aeo")
+ATB_VALUE_COLS = [
+    "cost_recovery_period_years",
+    "capacity_factor",
+    "capex_per_kw",
+    "capex_overnight_per_kw",
+    "capex_overnight_additional_per_kw",
+    "capex_grid_connection_per_kw",
+    "capex_construction_finance_factor",
+    "fuel_cost_per_mwh",
+    "heat_rate_mmbtu_per_mwh",
+    "heat_rate_penalty",
+    "levelized_cost_of_energy_per_mwh",
+    "net_output_penalty",
+    "opex_fixed_per_kw",
+    "opex_variable_per_mwh",
+    "wacc_real",
+]
 
-    tech_year = snakemake.wildcards.year
-    if int(tech_year) < 2024:
-        logger.warning(
-            "Minimum cost year supported is 2024, using 2024 expansion costs.",
-        )
-    years = range(2024, 2051)
-    tech_year = min(years, key=lambda x: abs(x - int(tech_year)))
 
-    emissions_data = EMISSIONS_DATA
-
-    # Path to parquet files
-    parquet_path = snakemake.params.pudl_path
-
-    # Import PUDLs ATB data
-    pudl_atb = load_pudl_atb_data(parquet_path)
-    pudl_atb["pypsa-name"] = pudl_atb.apply(
-        match_technology,
-        axis=1,
-        tech_dict=const.ATB_TECH_MAPPER,
-    )
-    pudl_atb = pudl_atb[pudl_atb["pypsa-name"].notnull()]
-
-    # Group by pypsa-name and filter for correct cost recovery period
-    pudl_atb = (
-        pudl_atb.groupby("pypsa-name")[pudl_atb.columns]
-        .apply(
-            lambda x: x[x["cost_recovery_period_years"] == const.ATB_TECH_MAPPER[x.name].get("crp", 30)],
-        )
-        .reset_index(drop=True)
-    )
-
-    # Filter for the correct year, scenario, and model case
-    pudl_atb_filt = pudl_atb[pudl_atb.projection_year == tech_year]
-    if tech_year < 2030:
-        logger.warning(
-            "Using 2030 ATB data for offwind_floating; earlier data not available.",
-        )
-        pudl_atb_offwind_floating = pudl_atb[
-            (pudl_atb["pypsa-name"] == "offwind_floating") & (pudl_atb.projection_year == 2030)
-        ]
-        pudl_atb = pd.concat(
-            [pudl_atb_filt, pudl_atb_offwind_floating],
-            ignore_index=True,
-        )
-    else:
-        pudl_atb = pudl_atb_filt
-
-    pudl_atb = pudl_atb[pudl_atb.scenario_atb == atb_params.get("scenario", "Moderate")]
-    pudl_atb = pudl_atb[pudl_atb.model_case_nrelatb == atb_params.get("model_case", "Market")]
-
-    pudl_premelt = pudl_atb.copy()
-    # Pivot Data
-    cols = [
-        "cost_recovery_period_years",
-        "capacity_factor",
-        "capex_per_kw",
-        "capex_overnight_per_kw",
-        "capex_overnight_additional_per_kw",
-        "capex_grid_connection_per_kw",
-        "capex_construction_finance_factor",
-        "fuel_cost_per_mwh",
-        "heat_rate_mmbtu_per_mwh",
-        "heat_rate_penalty",
-        "levelized_cost_of_energy_per_mwh",
-        "net_output_penalty",
-        "opex_fixed_per_kw",
-        "opex_variable_per_mwh",
-        "wacc_real",
-    ]
-    # pivot such that cols all get moved to one column
-    pudl_atb = pudl_atb.melt(
-        id_vars="pypsa-name",
-        value_vars=cols,
-        var_name="parameter",
-        value_name="value",
-    )
-
-    emissions_data = EMISSIONS_DATA
-
-    # Impute Transmission Data
-    # TEPCC 2023
-    # WACC & Lifetime: https://emp.lbl.gov/publications/improving-estimates-transmission
-    # Subsea costs: Purvins et al. (2018): https://doi.org/10.1016/j.jclepro.2018.03.095
-    transmission_data = [
-        {
-            "pypsa-name": "HVAC overhead",
-            "parameter": "capex_per_mw_km",
-            "value": 1541,
-        },
-        {
-            "pypsa-name": "HVAC overhead",
-            "parameter": "cost_recovery_period_years",
-            "value": 60,
-        },
-        {"pypsa-name": "HVAC overhead", "parameter": "wacc_real", "value": 0.044},
-        {
-            "pypsa-name": "HVDC overhead",
-            "parameter": "capex_per_mw_km",
-            "value": 1026.53,
-        },
-        {
-            "pypsa-name": "HVDC overhead",
-            "parameter": "cost_recovery_period_years",
-            "value": 60,
-        },
-        {"pypsa-name": "HVDC overhead", "parameter": "wacc_real", "value": 0.044},
-        {
-            "pypsa-name": "HVDC submarine",
-            "parameter": "capex_per_mw_km",
-            "value": 504.141,
-        },
-        {
-            "pypsa-name": "HVDC submarine",
-            "parameter": "cost_recovery_period_years",
-            "value": 60,
-        },
-        {"pypsa-name": "HVDC submarine", "parameter": "wacc_real", "value": 0.044},
-        {
-            "pypsa-name": "HVDC inverter pair",
-            "parameter": "capex_per_kw",
-            "value": 173.730,
-        },
-        {
-            "pypsa-name": "HVDC inverter pair",
-            "parameter": "cost_recovery_period_years",
-            "value": 60,
-        },
-        {"pypsa-name": "HVDC inverter pair", "parameter": "wacc_real", "value": 0.044},
-    ]
-    pudl_atb = pd.concat(
-        [
-            pudl_atb,
-            pd.DataFrame(emissions_data),
-            pd.DataFrame(transmission_data),
-            pd.DataFrame(LIFETIME_DATA),
-        ],
-        ignore_index=True,
-    )
-    pudl_atb = pudl_atb.drop_duplicates(
-        subset=["pypsa-name", "parameter"],
-        keep="last",
-    )
-
-    # Load AEO Fuel Cost Data
+def build_aeo_fuel_costs(parquet_path: str, tech_year: int, aeo_scenario: str) -> pd.DataFrame:
+    """Loads AEO fuel cost data, applies tech mappings, returns long-format frame."""
     aeo = load_pudl_aeo_data(parquet_path)
     aeo = aeo[aeo.projection_year == tech_year]
-    aeo = aeo[aeo.model_case_eiaaeo == aeo_params.get("scenario", "Reference")]
+    aeo = aeo[aeo.model_case_eiaaeo == aeo_scenario]
     cols = ["fuel_type_eiaaeo", "fuel_cost_real_per_mmbtu_eiaaeo"]
     aeo = aeo[cols]
     aeo = aeo.groupby("fuel_type_eiaaeo").mean()
@@ -429,11 +332,39 @@ if __name__ == "__main__":
             for new_name, source_name in tech_fuel_map.items()
         ],
     )
-    aeo = pd.concat([aeo, tech_fuels], ignore_index=True)
+    return pd.concat([aeo, tech_fuels], ignore_index=True)
+
+
+def process_atb_scenario(pudl_atb_sub: pd.DataFrame, aeo: pd.DataFrame) -> pd.DataFrame:
+    """Run the full cost pipeline for one (atb_scenario, model_case) slice.
+
+    Concatenates static data (emissions, transmission, lifetime, AEO fuels), pivots,
+    derives hydrogen_ct, marginal cost, annualized capex etc., and returns a long-form
+    DataFrame with columns [pypsa-name, parameter, value] for this scenario+case.
+    """
+    pudl_atb = pudl_atb_sub.melt(
+        id_vars="pypsa-name",
+        value_vars=ATB_VALUE_COLS,
+        var_name="parameter",
+        value_name="value",
+    )
+
+    pudl_atb = pd.concat(
+        [
+            pudl_atb,
+            pd.DataFrame(EMISSIONS_DATA),
+            pd.DataFrame(TRANSMISSION_DATA),
+            pd.DataFrame(LIFETIME_DATA),
+        ],
+        ignore_index=True,
+    )
+    pudl_atb = pudl_atb.drop_duplicates(
+        subset=["pypsa-name", "parameter"],
+        keep="last",
+    )
+
     pudl_atb = pd.concat([pudl_atb, aeo], ignore_index=True)
 
-    # Calculate Annualized Costs and Marinal Costs
-    # Apply: marginal_cost = opex_variable_per_mwh + fuel_cost_real_per_mwhth / efficiency
     pivot_atb = pudl_atb.pivot(
         index="pypsa-name",
         columns="parameter",
@@ -479,7 +410,6 @@ if __name__ == "__main__":
         )
         * pivot_atb["capex_per_kw"]
         * 1
-        # change to nyears
     ) * 1e3
 
     pivot_atb["annualized_capex_per_mw_km"] = (
@@ -489,12 +419,10 @@ if __name__ == "__main__":
         )
         * pivot_atb["capex_per_mw_km"]
         * 1
-        # change to nyears
     )
 
-    # Calculate grid interrconnection costs per MW-KM
-    # All land-based resources assume 1 mile of spur line
-    # All offshore resources assume 30 km of subsea cable
+    # Grid interconnection costs per MW-KM
+    # Land-based: 1 mile of spur line; offshore: 30 km of subsea cable
     pivot_atb["capex_grid_connection_per_kw_km"] = pivot_atb["capex_grid_connection_per_kw"] / 1.609
     pivot_atb.loc[
         pivot_atb["pypsa-name"].str.contains("offshore"),
@@ -508,23 +436,117 @@ if __name__ == "__main__":
         )
         * pivot_atb["capex_grid_connection_per_kw_km"]
         * 1
-        # change to nyears
     )
 
     pivot_atb["annualized_capex_fom"] = pivot_atb["annualized_capex_per_mw"] + (pivot_atb["opex_fixed_per_kw"] * 1e3)
-    pudl_atb = pivot_atb.melt(
+    result = pivot_atb.melt(
         id_vars=["pypsa-name"],
         value_vars=pivot_atb.columns.difference(["pypsa-name"]),
         var_name="parameter",
         value_name="value",
     )
-    pudl_atb = pudl_atb.reset_index(drop=True)
-    pudl_atb["value"] = pudl_atb["value"].round(3)
+    result = result.reset_index(drop=True)
+    result["value"] = result["value"].round(3)
+    return result
 
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake("build_cost_data", year=2030)
+        rootpath = ".."
+    else:
+        rootpath = "."
+
+    costs = snakemake.params.costs
+    atb_params = costs.get("atb") or {}
+    aeo_params = costs.get("aeo") or {}
+
+    tech_year = snakemake.wildcards.year
+    if int(tech_year) < 2024:
+        logger.warning(
+            "Minimum cost year supported is 2024, using 2024 expansion costs.",
+        )
+    years = range(2024, 2051)
+    tech_year = min(years, key=lambda x: abs(x - int(tech_year)))
+
+    # Path to parquet files
+    parquet_path = snakemake.params.pudl_path
+
+    # Import PUDLs ATB data
+    pudl_atb = load_pudl_atb_data(parquet_path)
+    pudl_atb["pypsa-name"] = pudl_atb.apply(
+        match_technology,
+        axis=1,
+        tech_dict=const.ATB_TECH_MAPPER,
+    )
+    pudl_atb = pudl_atb[pudl_atb["pypsa-name"].notnull()]
+
+    # Group by pypsa-name and filter for correct cost recovery period
+    pudl_atb = (
+        pudl_atb.groupby("pypsa-name")[pudl_atb.columns]
+        .apply(
+            lambda x: x[x["cost_recovery_period_years"] == const.ATB_TECH_MAPPER[x.name].get("crp", 30)],
+        )
+        .reset_index(drop=True)
+    )
+
+    # Filter to the requested projection year (with 2030 fallback for offwind_floating)
+    pudl_atb_filt = pudl_atb[pudl_atb.projection_year == tech_year]
+    if tech_year < 2030:
+        logger.warning(
+            "Using 2030 ATB data for offwind_floating; earlier data not available.",
+        )
+        pudl_atb_offwind_floating = pudl_atb[
+            (pudl_atb["pypsa-name"] == "offwind_floating") & (pudl_atb.projection_year == 2030)
+        ]
+        pudl_atb_year = pd.concat(
+            [pudl_atb_filt, pudl_atb_offwind_floating],
+            ignore_index=True,
+        )
+    else:
+        pudl_atb_year = pudl_atb_filt
+
+    # Build AEO fuel cost data once — independent of ATB scenario / case
+    aeo = build_aeo_fuel_costs(
+        parquet_path,
+        tech_year,
+        aeo_params.get("scenario", "Reference"),
+    )
+
+    # Iterate over every (atb_scenario, model_case) so that the final CSV holds
+    # the entire ATB scenario grid; downstream selects the correct slice via
+    # `costs.atb.scenario`/`model_case` (with optional per-carrier overrides).
+    scenarios = pudl_atb_year.scenario_atb.dropna().unique()
+    cases = pudl_atb_year.model_case_nrelatb.dropna().unique()
+    logger.info(
+        f"Building costs for {len(scenarios)} scenarios x {len(cases)} model cases "
+        f"= {len(scenarios) * len(cases)} ATB combinations",
+    )
+
+    scenario_results = []
+    for atb_scenario in scenarios:
+        for atb_model_case in cases:
+            sub = pudl_atb_year[
+                (pudl_atb_year.scenario_atb == atb_scenario) & (pudl_atb_year.model_case_nrelatb == atb_model_case)
+            ]
+            if sub.empty:
+                continue
+            result = process_atb_scenario(sub, aeo)
+            result["atb_scenario"] = atb_scenario
+            result["atb_model_case"] = atb_model_case
+            scenario_results.append(result)
+
+    pudl_atb = pd.concat(scenario_results, ignore_index=True)
+
+    # EGS costs do not vary with ATB scenario; tag as NA so the loader applies them universally
     egs_costs = pd.read_csv(snakemake.input.egs_costs)
     egs_costs = egs_costs.query("investment_horizon == @tech_year").drop(
         columns="investment_horizon",
     )
+    egs_costs["atb_scenario"] = pd.NA
+    egs_costs["atb_model_case"] = pd.NA
     pudl_atb = pd.concat([pudl_atb, egs_costs], ignore_index=True)
 
     pudl_atb.to_csv(snakemake.output.tech_costs, index=False)

--- a/workflow/scripts/cluster_network.py
+++ b/workflow/scripts/cluster_network.py
@@ -15,6 +15,7 @@ from _helpers import (
     calculate_annuity,
     configure_logging,
     is_transport_model,
+    load_costs,
     update_p_nom_max,
 )
 from add_electricity import update_transmission_costs
@@ -969,12 +970,10 @@ if __name__ == "__main__":
             linemap,
         )
 
-        costs = pd.read_csv(snakemake.input.tech_costs)
-        costs = costs.pivot(index="pypsa-name", columns="parameter", values="value")
+        costs = load_costs(snakemake.input.tech_costs, params.costs)
         hvac_overhead_cost = costs.at["HVAC overhead", "annualized_capex_per_mw_km"]
     else:
-        costs = pd.read_csv(snakemake.input.tech_costs)
-        costs = costs.pivot(index="pypsa-name", columns="parameter", values="value")
+        costs = load_costs(snakemake.input.tech_costs, params.costs)
         hvac_overhead_cost = costs.at["HVAC overhead", "annualized_capex_per_mw_km"]
 
         custom_busmap = params.custom_busmap

--- a/workflow/scripts/prepare_network.py
+++ b/workflow/scripts/prepare_network.py
@@ -19,6 +19,7 @@ import pypsa
 from _helpers import (
     configure_logging,
     is_transport_model,
+    load_costs,
     set_scenario_config,
     update_config_from_wildcards,
 )
@@ -288,8 +289,7 @@ if __name__ == "__main__":
 
     n = pypsa.Network(snakemake.input[0])
     num_years = n.snapshot_weightings.loc[n.investment_periods[0]].objective.sum() / 8760.0
-    costs = pd.read_csv(snakemake.input.tech_costs)
-    costs = costs.pivot(index="pypsa-name", columns="parameter", values="value")
+    costs = load_costs(snakemake.input.tech_costs, params.costs)
     # Set Investment Period Year Weightings
     # 'fillna(1)' needed if only one period
     inv_per_time_weight = n.investment_periods.to_series().diff().shift(-1).ffill().fillna(1)

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -352,7 +352,12 @@ def mask_future_generators(n, planning_horizon):
 
 
 def restore_future_generators(
-    n, future_gens, saved_extendable, saved_p_nom_max, saved_p_nom=None, saved_p_nom_min=None
+    n,
+    future_gens,
+    saved_extendable,
+    saved_p_nom_max,
+    saved_p_nom=None,
+    saved_p_nom_min=None,
 ):
     """Restore generator parameters masked by mask_future_generators."""
     if future_gens.empty:


### PR DESCRIPTION
## Summary
- `build_cost_data` now iterates over every `(atb_scenario, model_case_nrelatb)` slice from PUDL ATB and emits the full grid into `costs_{year}.csv` (new `atb_scenario` / `atb_model_case` columns). Static rows (EGS, transmission, emissions, lifetime) carry `NA` and apply universally.
- `costs.atb` config gains an optional `overrides` block keyed by pypsa-name so any carrier can be flipped to a different scenario / model_case without touching the global default. Resolution order: per-carrier override → global default → hardcoded `Moderate` / `Market` fallback.
- A single `_helpers.load_costs(path, costs_config)` reads the config and selects the right slice per carrier before pivoting; `add_electricity`, `prepare_network`, `cluster_network`, and `add_extra_components` now route through it instead of doing raw `pd.read_csv + pivot`. `add_extra_components` rule gains the `costs` param it was missing.
- Docs: extended `data-costs.md` with a step-by-step ATB-selection walkthrough and added rows to `configtables/costs.csv`.

The CSV grows ~6× (3 scenarios × 2 cases per ATB-derived row), but `build_cost_data` no longer needs to rerun when only `costs.atb` changes.

## Test plan
- [ ] Run `snakemake --cores 1 build_cost_data --config scenario.planning_horizons=[2030]` and confirm the new columns are populated for every carrier in `ATB_TECH_MAPPER`.
- [ ] Spot-check one carrier (e.g. `solar`) that the value at `(scenario=Advanced, model_case=Market)` differs from `(Moderate, Market)`.
- [ ] Run a full electricity-only build (`add_electricity` → `prepare_network`) with the default config and confirm results match develop's baseline.
- [ ] Set a per-carrier override (e.g. `solar.scenario: Advanced`) and re-run the downstream rules without re-running `build_cost_data`; confirm only `solar` rows in the resulting network change.
- [ ] Verify backward-compat: pointing `load_costs` at an older costs CSV without `atb_scenario` columns still pivots correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)