### PR TITLE
Myopic optimization fixes: retirement/extendability handling, transmission vintaging, and per-horizon plotting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+PyPSA-USA is a Snakemake workflow that builds and solves PyPSA energy-system optimization models of the US bulk power system (and optional sector coupling). Everything runs out of `workflow/` — `cd workflow` before invoking `snakemake`. Python is pinned to 3.11; dependencies are pinned exactly in `pyproject.toml` / `uv.lock`.
+
+## Common commands
+
+All snakemake commands run from `workflow/`. Choose ONE env manager (mamba or uv) — not both.
+
+```bash
+# First-time setup: copy config templates into workflow/config/
+bash init_pypsa_usa.sh
+
+# Full pipeline (solves + plots)
+uv run snakemake -j1 --configfile config/config.default.yaml --scheduler-ilp-solver GUROBI_CMD
+# or: mamba activate pypsa-usa && snakemake -j1 --configfile config/config.default.yaml
+
+# Build only the input data model (network .nc, no solve)
+uv run snakemake data_model -j1 --configfile config/config.default.yaml
+
+# Force-rerun a subset, stopping at a target rule
+snakemake -j4 -R build_shapes --until build_base_network
+
+# DAG of the workflow
+snakemake --rulegraph all | sed -n "/digraph/,\$p" | dot -Tjpg -o repo_data/dag.jpg
+
+# Wipe resources/ and results/ (keeps data/)
+snakemake clean
+
+# HPC (SLURM)
+bash run_slurm.sh   # edit --configfile inside the script first
+```
+
+Tests (pytest) live in `workflow/scripts/test/` and use the GLPK solver. Run from that directory or with that as cwd:
+
+```bash
+cd workflow/scripts/test && pytest -v
+pytest test_reserves.py::test_erm_peak_demand_hour -v
+pytest -v -k "storage"
+```
+
+Lint/format with ruff (config in `pyproject.toml`, line-length 120, py311 target):
+
+```bash
+ruff check --fix workflow/scripts
+ruff format workflow/scripts
+pre-commit run --all-files
+```
+
+## Architecture
+
+### Snakemake is the orchestrator
+- `workflow/Snakefile` is the entrypoint. It loads layered config (`config.cluster.yaml` → `config.common.yaml` → `config.plotting.yaml` → `config.api.yaml` → `config.sector.yaml`) and then any user `--configfile`, then `include:`s rule files from `workflow/rules/*.smk`.
+- Rule files group the pipeline stages: `retrieve.smk` (downloads), `build_electricity.smk` (network construction), `build_sector.smk` (sector coupling), `solve_electricity.smk`, `postprocess.smk` / `postprocess_sector.smk`, `validate.smk`, and `common.smk` (shared helpers).
+- Each rule's `script:` points at a Python file in `workflow/scripts/`. Scripts read inputs/outputs/params via the injected `snakemake` object — they aren't standalone CLIs.
+- Two convenience entrypoints: `rule all` (figures, the default) and `rule data_model` (build the prepared network `.nc` without solving).
+
+### Wildcards thread through filenames
+Wildcard constraints declared in `Snakefile`:
+- `interconnect`: `usa|texas|western|eastern`
+- `simpl`: simplification suffix (e.g. number of pre-clustering nodes)
+- `clusters`: `[0-9]+m?+a?+c?|all` — `m`/`c` suffixes change memory scaling in `common.smk:memory()`
+- `ll`: line-limit code, e.g. `v1.25`, `copt`, `vall`
+- `opts`: dash-separated option flags consumed by scripts (e.g. `Co2L-3h-25seg`)
+- `sector`: dash-joined letters from `{E, G}` (electricity, natural gas). Auto-prefixed with `E-` if missing.
+
+The canonical output filename pattern is:
+`elec_s{simpl}_c{clusters}_ec_l{ll}_{opts}_{sector}.nc` (data model) and similar under `results/{interconnect}/...`.
+
+### Resources layout is category-first
+`Snakefile` defines top-level path constants — files are grouped by *what they are*, not by interconnect:
+`NETWORKS`, `BUSMAPS`, `PROFILES`, `GEOSPATIAL`, `COSTS`, `PRICES`, `POWERPLANTS`, `DEMAND`, `HEATING_COP`, `TEMPERATURE`, `POPULATION`, `CO2` — each is `RESOURCES + "<name>/"`. When adding a new output, route it through one of these constants (or add a new category) instead of inventing an ad-hoc path. `RESOURCES` itself toggles between shared and per-run based on `run.shared_resources`.
+
+### Config provider pattern (common.smk)
+Rules don't read `config[...]` directly. They use `config_provider("key1", "key2", default=...)` from `workflow/rules/common.smk`. If `run.scenarios.enable` is true, this resolves config dynamically per `wildcards.run` via a scenarios file; otherwise it's a static lookup with wildcard interpolation. When adding rule params, follow this pattern so scenario overrides keep working.
+
+### Pipeline stages (high level)
+1. **Retrieve** (`retrieve.smk`) — pull Zenodo bundles, EIA, PUDL, NREL exclusion, EGS, gridemissions, etc.
+2. **Build base network** — shapes → bus regions → base network → cost data → powerplants → renewable profiles → demand.
+3. **Simplify & cluster** — `cluster_simpl.py` then `cluster_network.py` reduce nodes per `simpl`/`clusters` wildcards.
+4. **Add components** — `add_electricity.py`, `add_extra_components.py`, `add_demand.py`, `add_sectors.py`.
+5. **Prepare & solve** — `prepare_network.py` applies `opts` modifiers, `solve_network.py` calls the solver. Optional add-on constraints live in `workflow/scripts/opts/` (`reserves.py`, `policy.py`, `land.py`, `interchange.py`, `bidirectional_link.py`, `sector.py`).
+6. **Postprocess** — `summary*.py`, `plot_*.py` produce figures organized by category (maps / emissions / production / system / validate).
+
+### Solver
+Default is Gurobi (pinned `gurobipy==11.0.3`); HiGHS and GLPK also supported. Tests use GLPK. The EIA API key (required by default config for dynamic fuel prices) goes in `config/config.api.yaml`.

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -19,7 +19,7 @@ FIGURES_MAPS = [
     "emissions_map.pdf",
     "renewable_potential_map.pdf",
     "demand_map.pdf",
-    # "lmp_map.pdf",
+    "lmp_map.pdf",
 ]
 
 FIGURES_EMISSIONS = [

--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -826,6 +826,7 @@ def attach_egs(
                 p_max_pu=bus_profiles,
                 build_year=n.investment_periods[0],
                 lifetime=capital_recovery_period,
+                land_region=bus_list,
             )
 
 

--- a/workflow/scripts/add_extra_components.py
+++ b/workflow/scripts/add_extra_components.py
@@ -1721,14 +1721,18 @@ if __name__ == "__main__":
         add_elec_imports_exports(n, "exports", export_flowgates, fuel_costs, co2_emissions)
 
     if snakemake.config["scenario"]["sector"] == "E":
+        co2_storage = snakemake.config.get("co2", {}).get("storage", False)
+        co2_network_enable = snakemake.config.get("co2", {}).get("network", {}).get("enable", False)
+        dac_enable = snakemake.config.get("dac", {}).get("enable", False)
+
         # add node level CO2 (underground) storage
-        if snakemake.config["co2"]["storage"]:
+        if co2_storage:
             logger.info("Adding node level CO2 (underground) storage")
             add_co2_storage(n, snakemake.config, snakemake.input.co2_storage, costs, False)
 
         # add CO2 (transportation) network
-        if snakemake.config["co2"]["network"]["enable"]:
-            if snakemake.config["co2"]["storage"]:
+        if co2_network_enable:
+            if co2_storage:
                 logger.info("Adding CO2 (transportation) network")
                 add_co2_network(n, snakemake.config)
             else:
@@ -1737,8 +1741,8 @@ if __name__ == "__main__":
                 )
 
         # add node level DAC capabilities
-        if snakemake.config["dac"]["enable"]:
-            if snakemake.config["co2"]["storage"]:
+        if dac_enable:
+            if co2_storage:
                 logger.info("Adding DAC capabilities")
                 add_dac(n, snakemake.config, False)
             else:

--- a/workflow/scripts/add_sectors.py
+++ b/workflow/scripts/add_sectors.py
@@ -769,14 +769,18 @@ if __name__ == "__main__":
     # Needed as loads may be split off to urban/rural
     sanitize_carriers(n, snakemake.config)
 
+    co2_storage = snakemake.config.get("co2", {}).get("storage", False)
+    co2_network_enable = snakemake.config.get("co2", {}).get("network", {}).get("enable", False)
+    dac_enable = snakemake.config.get("dac", {}).get("enable", False)
+
     # add node level CO2 (underground) storage
-    if snakemake.config["co2"]["storage"]:
+    if co2_storage:
         logger.info("Adding node level CO2 (underground) storage")
         add_co2_storage(n, snakemake.config, snakemake.input.co2_storage, costs, True)
 
     # add CO2 (transportation) network
-    if snakemake.config["co2"]["network"]["enable"]:
-        if snakemake.config["co2"]["storage"]:
+    if co2_network_enable:
+        if co2_storage:
             logger.info("Adding CO2 (transportation) network")
             add_co2_network(n, snakemake.config)
         else:
@@ -785,9 +789,9 @@ if __name__ == "__main__":
             )
 
     # add node level DAC capabilities
-    if snakemake.config["dac"]["enable"]:
+    if dac_enable:
         raise ValueError("DAC is not supported for Sector Studies. See https://github.com/PyPSA/pypsa-usa/issues/652")
-        if snakemake.config["co2"]["storage"]:
+        if co2_storage:
             logger.info("Adding DAC capabilities")
             add_dac(n, snakemake.config, True)
         else:

--- a/workflow/scripts/cluster_network.py
+++ b/workflow/scripts/cluster_network.py
@@ -33,6 +33,8 @@ idx = pd.IndexSlice
 
 logger = logging.getLogger(__name__)
 
+TRANSMISSION_LIFETIME = 60  # years; matches HVAC/HVDC cost_recovery_period_years in build_cost_data.py
+
 
 def normed(x):
     return (x / x.sum()).fillna(0.0)
@@ -366,13 +368,20 @@ def clustering_for_n_clusters(
     return clustering
 
 
-def add_itls(buses, itls, itl_cost, expansion=True):
+def add_itls(buses, itls, itl_cost, planning_horizons, lifetime, expansion=True):
     """
     Adds ITL limits to the network.
 
     Adds bi-directional links for all ITLS which are non-expandable.
     Adds a second link that is expandable with equal expansion in each
     direction.
+
+    For each ITL, the original fwd/rev links are stamped at the first planning
+    horizon and carry the existing REEDS capacity (mw_f0/mw_r0). For every
+    subsequent horizon, a vintaged duplicate is added with p_nom=0 and
+    build_year set to that horizon, so prepare_network can flip them to
+    extendable and the optimizer can build new vintage-tagged transmission
+    capacity in each period.
     """
     if itl_cost is not None:
         itl_cost["interface"] = itl_cost.r + "||" + itl_cost.rr
@@ -392,6 +401,16 @@ def add_itls(buses, itls, itl_cost, expansion=True):
 
     itls["efficiency"] = 1 - ((itls.length_miles / 100) * 0.01)
 
+    sorted_horizons = sorted(int(h) for h in planning_horizons)
+    first_horizon = sorted_horizons[0]
+    future_horizons = sorted_horizons[1:]
+
+    length_km = 0 if itl_cost is None else itls.length_miles.values * 1.6093  # mile to km
+    capital_cost = (
+        0 if itl_cost is None else itls.USD2023perMWyr.values / 2
+    )  # divide by 2 to avoid accounting for the capital cost repeatedly
+    efficiency = 1 if itl_cost is None else itls.efficiency.values
+
     # The fwd and rev links will be made extendable in prepare_network, so no need to add AC_exp
     clustering.network.madd(
         "Link",
@@ -403,13 +422,13 @@ def add_itls(buses, itls, itl_cost, expansion=True):
         p_nom_min=itls.mw_f0.values,
         p_max_pu=1.0,
         p_min_pu=0.0,
-        length=0 if itl_cost is None else itls.length_miles.values * 1.6093,  # mile to km
-        capital_cost=0
-        if itl_cost is None
-        else itls.USD2023perMWyr.values / 2,  # divide by 2 to avoid accounting for the capital cost repeatedly
+        length=length_km,
+        capital_cost=capital_cost,
         p_nom_extendable=False,
-        efficiency=1 if itl_cost is None else itls.efficiency.values,
+        efficiency=efficiency,
         carrier="AC",
+        build_year=first_horizon,
+        lifetime=lifetime,
     )
 
     clustering.network.madd(
@@ -422,14 +441,55 @@ def add_itls(buses, itls, itl_cost, expansion=True):
         p_nom_min=itls.mw_r0.values,
         p_max_pu=1.0,
         p_min_pu=0.0,
-        length=0 if itl_cost is None else itls.length_miles.values * 1.6093,  # mile to km
-        capital_cost=0
-        if itl_cost is None
-        else itls.USD2023perMWyr.values / 2,  # divide by 2 to avoid accounting for the capital cost repeatedly
+        length=length_km,
+        capital_cost=capital_cost,
         p_nom_extendable=False,
-        efficiency=1 if itl_cost is None else itls.efficiency.values,
+        efficiency=efficiency,
         carrier="AC",
+        build_year=first_horizon,
+        lifetime=lifetime,
     )
+
+    # Vintaged duplicates: one per future horizon, starting at p_nom=0. prepare_network
+    # will flip these to extendable alongside the originals so each period can build
+    # new transmission capacity tagged with its own build_year.
+    for horizon in future_horizons:
+        clustering.network.madd(
+            "Link",
+            names=itls.interface,
+            suffix=f"_fwd_{horizon}",
+            bus0=buses.loc[itls.r].index,
+            bus1=buses.loc[itls.rr].index,
+            p_nom=0.0,
+            p_nom_min=0.0,
+            p_max_pu=1.0,
+            p_min_pu=0.0,
+            length=length_km,
+            capital_cost=capital_cost,
+            p_nom_extendable=False,
+            efficiency=efficiency,
+            carrier="AC",
+            build_year=horizon,
+            lifetime=lifetime,
+        )
+        clustering.network.madd(
+            "Link",
+            names=itls.interface,
+            suffix=f"_rev_{horizon}",
+            bus0=buses.loc[itls.rr].index,
+            bus1=buses.loc[itls.r].index,
+            p_nom=0.0,
+            p_nom_min=0.0,
+            p_max_pu=1.0,
+            p_min_pu=0.0,
+            length=length_km,
+            capital_cost=capital_cost,
+            p_nom_extendable=False,
+            efficiency=efficiency,
+            carrier="AC",
+            build_year=horizon,
+            lifetime=lifetime,
+        )
 
 
 def convert_to_transport(
@@ -440,6 +500,8 @@ def convert_to_transport(
     itl_agg_costs_fn,
     topological_boundaries,
     topology_aggregation,
+    planning_horizons,
+    lifetime,
 ):
     """
     Replaces all Lines according to Links with the transfer capacity specified
@@ -460,7 +522,7 @@ def convert_to_transport(
             itls.r.isin(clustering.network.buses[f"{topological_boundaries}"])
             & itls.rr.isin(clustering.network.buses[f"{topological_boundaries}"])
         ]
-    add_itls(buses, itls_filt, itl_cost)
+    add_itls(buses, itls_filt, itl_cost, planning_horizons, lifetime)
 
     if itl_agg_fn:
         # Aggregating the ITLs to lower resolution
@@ -507,7 +569,7 @@ def convert_to_transport(
 
         itl_lower_res = pd.concat([itl_lower_res, itls_between])
         itl_agg_costs = None if itl_agg_costs_fn is None else pd.concat([itl_cost, pd.read_csv(itl_agg_costs_fn)])
-        add_itls(buses, itl_lower_res, itl_agg_costs, expansion=True)
+        add_itls(buses, itl_lower_res, itl_agg_costs, planning_horizons, lifetime, expansion=True)
         itls = pd.concat([itls_filt, itl_lower_res])
     else:
         itls = itls_filt
@@ -525,6 +587,9 @@ def convert_to_transport(
         buses_p20 = clustering.network.buses[clustering.network.buses.reeds_zone == "p20"]
         existing_links = clustering.network.links[clustering.network.links.bus0.isin(buses_p19.index)]
         if existing_links.empty:
+            sorted_horizons = sorted(int(h) for h in planning_horizons)
+            first_horizon = sorted_horizons[0]
+            future_horizons = sorted_horizons[1:]
             clustering.network.madd(
                 "Link",
                 names=["p19_to_p20"],
@@ -535,7 +600,23 @@ def convert_to_transport(
                 p_min_pu=-1,
                 p_nom_extendable=False,
                 carrier="AC",
+                build_year=first_horizon,
+                lifetime=lifetime,
             )
+            for horizon in future_horizons:
+                clustering.network.madd(
+                    "Link",
+                    names=[f"p19_to_p20_{horizon}"],
+                    bus0=buses_p19.iloc[0].name,
+                    bus1=buses_p20.iloc[0].name,
+                    p_nom=0,
+                    length=0,
+                    p_min_pu=-1,
+                    p_nom_extendable=False,
+                    carrier="AC",
+                    build_year=horizon,
+                    lifetime=lifetime,
+                )
 
     # Remove any disconnected buses
     unique_buses = buses.loc[itls.r].index.union(buses.loc[itls.rr].index).unique()
@@ -595,6 +676,8 @@ def calibrate_tamu_transmission_capacity(
     s_max_pu,
     length_factor,
     costs,
+    build_year,
+    lifetime,
     use_original_region=False,
 ):
     """
@@ -617,6 +700,10 @@ def calibrate_tamu_transmission_capacity(
         Factor to multiply air-line distance for line length calculation
     costs : pd.DataFrame
         Technology costs dataframe with transmission line cost parameters
+    build_year : int
+        Build year stamped on calibrated existing TAMU lines and new REEDS-backfill lines.
+    lifetime : int | float
+        Lifetime stamped on calibrated existing TAMU lines and new REEDS-backfill lines.
     use_original_region : bool
         If True, use original region info saved before aggregation
     """
@@ -719,6 +806,9 @@ def calibrate_tamu_transmission_capacity(
 
             # Update s_nom
             clustering.network.lines.loc[line_idx, "s_nom"] = new_s_nom
+            # Stamp these as existing brownfield infrastructure
+            clustering.network.lines.loc[line_idx, "build_year"] = build_year
+            clustering.network.lines.loc[line_idx, "lifetime"] = lifetime
 
             # Update electrical parameters based on power system principles
             if capacity_ratio != 1.0:
@@ -869,6 +959,8 @@ def calibrate_tamu_transmission_capacity(
             capital_cost=new_lines_df["capital_cost"].values,
             interconnect=new_lines_df["interconnect"].values,
             num_parallel=new_lines_df["num_parallel"].values,
+            build_year=build_year,
+            lifetime=lifetime,
         )
 
     logger.info(
@@ -896,6 +988,11 @@ if __name__ == "__main__":
     n.set_investment_periods(
         periods=snakemake.params.planning_horizons,
     )
+
+    # Stamp REEDS-derived and existing transmission as pre-existing brownfield infrastructure
+    # so PyPSA's per-period active-asset logic treats them correctly across investment periods.
+    transmission_build_year = int(min(snakemake.params.planning_horizons))
+    transmission_lifetime = TRANSMISSION_LIFETIME
 
     topological_boundaries = params.topological_boundaries
     transport_model = is_transport_model(params.transmission_network)
@@ -1086,6 +1183,8 @@ if __name__ == "__main__":
                 itl_agg_costs_fn,
                 topological_boundaries,
                 topology_aggregation,
+                snakemake.params.planning_horizons,
+                transmission_lifetime,
             )
         else:
             # Use standard transmission cost estimates
@@ -1125,8 +1224,25 @@ if __name__ == "__main__":
             s_max_pu,
             params.length_factor,
             costs,
+            transmission_build_year,
+            transmission_lifetime,
             use_original_region=use_original_region,
         )
+
+    # Defensive backstop: stamp any transmission Line/Link still carrying PyPSA's default
+    # build_year=0 / lifetime=inf so existing infrastructure (e.g. TAMU lines from
+    # build_base_network.py) is treated as pre-existing brownfield in myopic per-period
+    # accounting. The targeted edits in convert_to_transport/calibrate_tamu_transmission_capacity
+    # already cover the REEDS path; this catches everything else.
+    lines = clustering.network.lines
+    if not lines.empty:
+        lines.loc[lines["build_year"] == 0, "build_year"] = transmission_build_year
+        lines.loc[~np.isfinite(lines["lifetime"]), "lifetime"] = transmission_lifetime
+    links = clustering.network.links
+    if not links.empty:
+        transmission_link_mask = links["carrier"].isin(["AC", "DC"])
+        links.loc[transmission_link_mask & (links["build_year"] == 0), "build_year"] = transmission_build_year
+        links.loc[transmission_link_mask & ~np.isfinite(links["lifetime"]), "lifetime"] = transmission_lifetime
 
     update_p_nom_max(clustering.network)
     clustering.network.generators.land_region = clustering.network.generators.land_region.fillna(

--- a/workflow/scripts/opts/land.py
+++ b/workflow/scripts/opts/land.py
@@ -37,6 +37,6 @@ def add_land_use_constraints(n):
     if not index.empty:
         logger.info("Adding land-use constraints")
         model.add_constraints(
-            lhs.sel(group=index) <= rhs.loc[index],
+            lhs.sel(group=index) <= rhs.loc[index],  # subtrack previous build from the maximum allowed
             name="land_use_constraint",
         )

--- a/workflow/scripts/plot_network_maps.py
+++ b/workflow/scripts/plot_network_maps.py
@@ -35,7 +35,7 @@ import seaborn as sns
 from _helpers import configure_logging
 from add_electricity import sanitize_carriers
 from cartopy import crs as ccrs
-from matplotlib.colors import Normalize
+from matplotlib.colors import LinearSegmentedColormap, Normalize
 from pypsa.plot import add_legend_circles, add_legend_lines, add_legend_patches
 from summary import (
     get_node_emissions_timeseries,
@@ -684,14 +684,22 @@ def plot_demand_map(
     if n_h == 1:
         axes = [axes]
 
+    # Use a truncated Blues palette so the low end starts at a slightly darker
+    # blue (skipping the near-white portion of matplotlib's built-in Blues).
+    base_blues = plt.colormaps["Blues"]
+    blues_truncated = LinearSegmentedColormap.from_list(
+        "BluesTruncated",
+        base_blues(np.linspace(0.25, 1.0, 256)),
+    )
+
     for ax, horizon in zip(axes, horizons):
         values = horizon_values[horizon]
-        _plot_choropleth_on_ax(n, values, regions, ax, cmap="Blues", vmin=vmin, vmax=vmax)
+        _plot_choropleth_on_ax(n, values, regions, ax, cmap=blues_truncated, vmin=vmin, vmax=vmax)
         h_label = "" if horizon is None else f" — {horizon}"
         ax.set_title(f"Mean Nodal Demand (MW){h_label}", fontsize=TITLE_SIZE - 2)
 
     # Shared colorbar on the right edge.
-    sm = plt.cm.ScalarMappable(cmap="Blues", norm=Normalize(vmin=vmin, vmax=vmax))
+    sm = plt.cm.ScalarMappable(cmap=blues_truncated, norm=Normalize(vmin=vmin, vmax=vmax))
     sm.set_array([])
     cbar = fig.colorbar(sm, ax=axes, orientation="vertical", fraction=0.025, pad=0.02)
     cbar.set_label("Mean Demand (MW)")

--- a/workflow/scripts/plot_network_maps.py
+++ b/workflow/scripts/plot_network_maps.py
@@ -480,6 +480,20 @@ def plot_new_capacity_map(
     bus_values = bus_values[(bus_values > 0) & (bus_values.index.get_level_values(1).isin(carriers))]
     bus_values = remove_sector_buses(bus_values).reset_index().groupby(by=["bus", "carrier"]).sum().squeeze()
 
+    title = create_title("New Network Capacities", **wildcards)
+
+    # n.plot() calls np.nanmin over bus coords; an empty bus_values yields an
+    # empty array and crashes the bbox computation. Save a placeholder instead.
+    if bus_values.empty:
+        logger.warning("No new capacity for carriers %s; saving placeholder map.", carriers)
+        fig, ax = plt.subplots(figsize=(10, 10))
+        ax.text(0.5, 0.5, "No new capacity built", ha="center", va="center", fontsize=14)
+        ax.set_title(title, fontsize=TITLE_SIZE, pad=20)
+        ax.axis("off")
+        fig.savefig(save)
+        plt.close()
+        return
+
     line_snom = n.lines.s_nom
     line_snom_opt = n.lines.s_nom_opt
     line_values = line_snom_opt - line_snom
@@ -489,7 +503,6 @@ def plot_new_capacity_map(
     link_values = link_pnom_opt - link_pnom
 
     # plot data
-    title = create_title("New Network Capacities", **wildcards)
     interconnect = wildcards.get("interconnect", None)
     bus_scale = get_bus_scale(interconnect) if interconnect else 1
     line_scale = get_line_scale(interconnect) if interconnect else 1

--- a/workflow/scripts/plot_network_maps.py
+++ b/workflow/scripts/plot_network_maps.py
@@ -686,12 +686,12 @@ def plot_demand_map(
 
     for ax, horizon in zip(axes, horizons):
         values = horizon_values[horizon]
-        _plot_choropleth_on_ax(n, values, regions, ax, cmap="viridis", vmin=vmin, vmax=vmax)
+        _plot_choropleth_on_ax(n, values, regions, ax, cmap="Blues", vmin=vmin, vmax=vmax)
         h_label = "" if horizon is None else f" — {horizon}"
         ax.set_title(f"Mean Nodal Demand (MW){h_label}", fontsize=TITLE_SIZE - 2)
 
     # Shared colorbar on the right edge.
-    sm = plt.cm.ScalarMappable(cmap="viridis", norm=Normalize(vmin=vmin, vmax=vmax))
+    sm = plt.cm.ScalarMappable(cmap="Blues", norm=Normalize(vmin=vmin, vmax=vmax))
     sm.set_array([])
     cbar = fig.colorbar(sm, ax=axes, orientation="vertical", fraction=0.025, pad=0.02)
     cbar.set_label("Mean Demand (MW)")

--- a/workflow/scripts/plot_network_maps.py
+++ b/workflow/scripts/plot_network_maps.py
@@ -35,11 +35,9 @@ import seaborn as sns
 from _helpers import configure_logging
 from add_electricity import sanitize_carriers
 from cartopy import crs as ccrs
+from matplotlib.colors import Normalize
 from pypsa.plot import add_legend_circles, add_legend_lines, add_legend_patches
 from summary import (
-    get_capacity_base,
-    get_capacity_brownfield,
-    get_demand_base,
     get_node_emissions_timeseries,
 )
 
@@ -47,6 +45,72 @@ logger = logging.getLogger(__name__)
 
 # Global Plotting Settings
 TITLE_SIZE = 16
+
+
+def _get_investment_periods(n: pypsa.Network) -> list:
+    """Return the list of investment periods, or a single dummy [None] when not multi-period."""
+    if hasattr(n, "investment_periods") and len(n.investment_periods) > 0:
+        return list(n.investment_periods)
+    return [None]
+
+
+def _active_mask(df: pd.DataFrame, horizon) -> pd.Series:
+    """Boolean mask: asset active in `horizon` (build_year <= horizon < build_year + lifetime).
+
+    When `horizon` is None (single-period case), all rows are considered active.
+    """
+    if horizon is None or "build_year" not in df.columns:
+        return pd.Series(True, index=df.index)
+    lifetime = df["lifetime"] if "lifetime" in df.columns else pd.Series(np.inf, index=df.index)
+    return (df["build_year"] <= horizon) & (horizon < df["build_year"] + lifetime)
+
+
+def _capacity_by_bus_carrier(
+    n: pypsa.Network,
+    horizon,
+    attr: str,
+) -> pd.Series:
+    """Sum `attr` (e.g. p_nom, p_nom_opt) of active assets at `horizon` by (bus, carrier).
+
+    Mirrors `summary.get_capacity_brownfield` but filters by activity in `horizon`.
+    """
+    parts = []
+    for c in n.iterate_components(["Generator", "StorageUnit", "Link"]):
+        mask = _active_mask(c.df, horizon)
+        if not mask.any():
+            continue
+        df = c.df.loc[mask]
+        if c.name == "Link":
+            parts.append(df[attr].groupby([df.bus0, df.carrier]).sum().rename_axis(index={"bus0": "bus"}))
+            parts.append(df[attr].groupby([df.bus1, df.carrier]).sum().rename_axis(index={"bus1": "bus"}))
+        else:
+            parts.append(df[attr].groupby([df.bus, df.carrier]).sum())
+    if not parts:
+        return pd.Series(dtype=float, index=pd.MultiIndex.from_tuples([], names=["bus", "carrier"]))
+    return pd.concat(parts)
+
+
+def _line_link_capacity(
+    n: pypsa.Network,
+    horizon,
+    attr_line: str,
+    attr_link: str,
+) -> tuple[pd.Series, pd.Series]:
+    """Return (line_values, link_values) for active lines/AC-links at `horizon`."""
+    line_mask = _active_mask(n.lines, horizon)
+    line_values = n.lines.loc[line_mask, attr_line] if line_mask.any() else pd.Series(0, index=n.lines.index)
+
+    ac_links = n.links[n.links.carrier == "AC"]
+    link_mask = _active_mask(ac_links, horizon)
+    link_values = (
+        ac_links.loc[link_mask, attr_link].replace(to_replace={pd.NA: 0})
+        if link_mask.any()
+        else pd.Series(
+            0,
+            index=ac_links.index,
+        )
+    )
+    return line_values, link_values
 
 
 def get_color_palette(n: pypsa.Network) -> pd.Series:
@@ -215,6 +279,108 @@ def plot_emissions_map(
     plt.close()
 
 
+def _plot_capacity_on_ax(
+    n: pypsa.Network,
+    bus_values: pd.Series,
+    line_values: pd.Series,
+    link_values: pd.Series,
+    regions: gpd.GeoDataFrame,
+    ax,
+    bus_scale=1,
+    line_scale=1,
+    line_colors="teal",
+    link_colors="green",
+    line_cmap="viridis",
+    line_norm=None,
+    flow=None,
+) -> dict:
+    """Draw the capacity pie-chart map onto an existing axis.
+
+    Returns a dict with bus_colors and nice_names so the caller can attach a
+    shared legend at the figure level when used inside a subplot grid.
+    """
+    carrier_exclusion = ["imports", "exports", "demand_response"]
+    bus_colors = n.carriers.color[~n.carriers.color.index.isin(carrier_exclusion)].fillna("#000000")
+    nice_names = n.carriers.nice_name[~n.carriers.nice_name.index.isin(carrier_exclusion)].fillna("Other")
+
+    # Drop any (bus, carrier) rows whose carrier isn't in bus_colors — n.plot()
+    # raises ValueError("Colors not defined for all elements...") otherwise.
+    if not bus_values.empty and "carrier" in bus_values.index.names:
+        bus_values = bus_values[bus_values.index.get_level_values("carrier").isin(bus_colors.index)]
+
+    line_width = line_values / line_scale
+    link_width = link_values / line_scale
+
+    # Draw region tiles first as the geographic backdrop.
+    regions.plot(
+        ax=ax,
+        facecolor="whitesmoke",
+        edgecolor="white",
+        aspect="equal",
+        transform=ccrs.PlateCarree(),
+        linewidth=1.2,
+    )
+
+    # Empty bus_values would make n.plot()'s bbox compute crash on an empty
+    # array. Skip the network draw and leave the region backdrop in place.
+    if not bus_values.empty:
+        with plt.rc_context({"patch.linewidth": 0.1}):
+            n.plot(
+                bus_sizes=bus_values / bus_scale,
+                bus_colors=bus_colors,
+                bus_alpha=0.7,
+                line_widths=line_width,
+                link_widths=0 if link_width.empty else link_width,
+                line_colors=line_colors,
+                link_colors=link_colors,
+                ax=ax,
+                margin=0.2,
+                color_geomap=True,
+                flow=flow,
+                line_cmap=line_cmap,
+                line_norm=line_norm,
+            )
+
+    ax.set_extent(regions.total_bounds[[0, 2, 1, 3]])
+
+    return {"bus_colors": bus_colors, "nice_names": nice_names}
+
+
+def _add_capacity_legends(
+    fig,
+    ax,
+    bus_colors,
+    nice_names,
+    bus_scale,
+    line_scale,
+    *,
+    bbox_anchor=(1, 1),
+) -> None:
+    """Attach the standard capacity-map legends (sizes + carrier patches)."""
+    legend_kwargs = {"loc": "upper left", "frameon": False}
+    bus_sizes = [5000, 10e3, 50e3]  # MW
+    line_sizes = [2000, 5000]  # MW
+
+    add_legend_circles(
+        ax,
+        [s / bus_scale for s in bus_sizes],
+        [f"{s / 1000:.0f} GW" for s in bus_sizes],
+        legend_kw={"bbox_to_anchor": bbox_anchor, "labelspacing": 3, **legend_kwargs},
+    )
+    add_legend_lines(
+        ax,
+        [s / line_scale for s in line_sizes],
+        [f"{s / 1000:.0f} GW" for s in line_sizes],
+        legend_kw={"bbox_to_anchor": (bbox_anchor[0], bbox_anchor[1] - 0.2), **legend_kwargs},
+    )
+    add_legend_patches(
+        ax,
+        bus_colors,
+        nice_names,
+        legend_kw={"bbox_to_anchor": (bbox_anchor[0], 0), **legend_kwargs, "loc": "lower left"},
+    )
+
+
 def plot_capacity_map(
     n: pypsa.Network,
     bus_values: pd.DataFrame,
@@ -230,77 +396,263 @@ def plot_capacity_map(
     line_cmap="viridis",
     line_norm=None,
 ) -> tuple[plt.figure, plt.axes]:
-    """Generic network plotting function for capacity pie charts at each node."""
+    """Generic single-axis capacity pie-chart map."""
     fig, ax = plt.subplots(
         figsize=(10, 10),
         subplot_kw={"projection": ccrs.EqualEarth(n.buses.x.mean())},
     )
 
-    carrier_exclusion = ["imports", "exports", "demand_response"]
+    artifacts = _plot_capacity_on_ax(
+        n,
+        bus_values,
+        line_values,
+        link_values,
+        regions,
+        ax,
+        bus_scale=bus_scale,
+        line_scale=line_scale,
+        line_colors=line_colors,
+        link_colors=link_colors,
+        line_cmap=line_cmap,
+        line_norm=line_norm,
+        flow=flow,
+    )
+    _add_capacity_legends(fig, ax, artifacts["bus_colors"], artifacts["nice_names"], bus_scale, line_scale)
 
-    bus_colors = n.carriers.color[~n.carriers.color.index.isin(carrier_exclusion)].fillna("#000000")
-    nice_names = n.carriers.nice_name[~n.carriers.nice_name.index.isin(carrier_exclusion)].fillna("Other")
+    ax.set_title(title or "Capacity (MW)", fontsize=TITLE_SIZE, pad=20)
+    fig.tight_layout()
+    return fig, ax
 
-    line_width = line_values / line_scale
-    link_width = link_values / line_scale
 
-    with plt.rc_context({"patch.linewidth": 0.1}):
-        n.plot(
-            bus_sizes=bus_values / bus_scale,
-            bus_colors=bus_colors,
-            bus_alpha=0.7,
-            line_widths=line_width,
-            link_widths=0 if link_width.empty else link_width,
-            line_colors=line_colors,
-            link_colors=link_colors,
-            ax=ax,
-            margin=0.2,
-            color_geomap=True,
-            flow=flow,
-            line_cmap=line_cmap,
-            line_norm=line_norm,
+def plot_capacity_map_by_horizon(
+    n: pypsa.Network,
+    regions: gpd.GeoDataFrame,
+    carriers: list[str],
+    save: str,
+    kind: str,
+    **wildcards,
+) -> None:
+    """Plot a capacity-pie-chart map per investment period.
+
+    `kind` selects the data:
+        - "base"     : pre-solve installed capacity active in each horizon
+        - "optimal"  : optimized capacity active in each horizon
+        - "new"      : capacity vintaged to that specific horizon (built then)
+    """
+    horizons = _get_investment_periods(n)
+    if len(horizons) == 1:
+        # Fall back to the single-axis layout when only one horizon exists.
+        bus_attr_for_kind = {"base": "p_nom", "optimal": "p_nom_opt", "new": "p_nom_opt"}
+        attr = bus_attr_for_kind[kind]
+        bus_values = _capacity_by_bus_carrier(n, horizons[0], attr)
+        if kind == "new":
+            # `new` is p_nom_opt - p_nom for assets vintaged in this horizon.
+            base_bv = _capacity_by_bus_carrier(n, horizons[0], "p_nom")
+            bus_values = (bus_values - base_bv.reindex(bus_values.index, fill_value=0)).clip(lower=0)
+        bus_values = bus_values[bus_values.index.get_level_values("carrier").isin(carriers)]
+        bus_values = remove_sector_buses(bus_values).groupby(["bus", "carrier"]).sum()
+
+        line_attr = "s_nom_opt" if kind != "base" else "s_nom"
+        link_attr = "p_nom_opt" if kind != "base" else "p_nom"
+        line_values, link_values = _line_link_capacity(n, horizons[0], line_attr, link_attr)
+        if kind == "new":
+            line_base, link_base = _line_link_capacity(n, horizons[0], "s_nom", "p_nom")
+            line_values = (line_values - line_base).clip(lower=0)
+            link_values = (link_values - link_base).clip(lower=0)
+
+        kind_titles = {"base": "Base", "optimal": "Optimal", "new": "New"}
+        title = create_title(f"{kind_titles[kind]} Network Capacities", **wildcards)
+        interconnect = wildcards.get("interconnect")
+        bus_scale = get_bus_scale(interconnect) if interconnect else 1
+        line_scale = get_line_scale(interconnect) if interconnect else 1
+
+        if bus_values.empty and kind == "new":
+            fig, ax = plt.subplots(figsize=(10, 10))
+            ax.text(0.5, 0.5, "No new capacity built", ha="center", va="center", fontsize=14)
+            ax.set_title(title, fontsize=TITLE_SIZE, pad=20)
+            ax.axis("off")
+        else:
+            fig, _ = plot_capacity_map(
+                n=n,
+                bus_values=bus_values,
+                line_values=line_values,
+                link_values=link_values,
+                regions=regions,
+                bus_scale=bus_scale,
+                line_scale=line_scale,
+                title=title,
+            )
+        fig.savefig(save)
+        plt.close()
+        return
+
+    # Multi-horizon: one column per horizon, shared legend on the right.
+    n_h = len(horizons)
+    fig, axes = plt.subplots(
+        1,
+        n_h,
+        figsize=(8 * n_h, 8.5),
+        subplot_kw={"projection": ccrs.EqualEarth(n.buses.x.mean())},
+    )
+    if n_h == 1:
+        axes = [axes]
+
+    interconnect = wildcards.get("interconnect")
+    bus_scale = get_bus_scale(interconnect) if interconnect else 1
+    line_scale = get_line_scale(interconnect) if interconnect else 1
+
+    artifacts = None
+    for ax, horizon in zip(axes, horizons):
+        if kind == "base":
+            bus_values = _capacity_by_bus_carrier(n, horizon, "p_nom")
+            line_values, link_values = _line_link_capacity(n, horizon, "s_nom", "p_nom")
+        elif kind == "optimal":
+            bus_values = _capacity_by_bus_carrier(n, horizon, "p_nom_opt")
+            line_values, link_values = _line_link_capacity(n, horizon, "s_nom_opt", "p_nom_opt")
+        elif kind == "new":
+            # Restrict to assets vintaged to this horizon: built_year == horizon.
+            parts = []
+            for c in n.iterate_components(["Generator", "StorageUnit", "Link"]):
+                df = c.df[c.df.get("build_year") == horizon] if "build_year" in c.df.columns else c.df.iloc[0:0]
+                if df.empty:
+                    continue
+                if c.name == "Link":
+                    parts.append(
+                        df["p_nom_opt"].groupby([df.bus0, df.carrier]).sum().rename_axis(index={"bus0": "bus"}),
+                    )
+                    parts.append(
+                        df["p_nom_opt"].groupby([df.bus1, df.carrier]).sum().rename_axis(index={"bus1": "bus"}),
+                    )
+                else:
+                    parts.append(df["p_nom_opt"].groupby([df.bus, df.carrier]).sum())
+            bus_values = (
+                pd.concat(parts)
+                if parts
+                else pd.Series(
+                    dtype=float,
+                    index=pd.MultiIndex.from_tuples([], names=["bus", "carrier"]),
+                )
+            )
+            # New transmission for this horizon: lines/links vintaged here.
+            line_mask = n.lines.get("build_year", pd.Series(np.nan, index=n.lines.index)) == horizon
+            line_values = n.lines.loc[line_mask, "s_nom_opt"] if line_mask.any() else pd.Series(0, index=n.lines.index)
+            ac_links = n.links[n.links.carrier == "AC"]
+            link_mask = ac_links.get("build_year", pd.Series(np.nan, index=ac_links.index)) == horizon
+            link_values = (
+                ac_links.loc[link_mask, "p_nom_opt"].replace(to_replace={pd.NA: 0})
+                if link_mask.any()
+                else pd.Series(0, index=ac_links.index)
+            )
+        else:
+            raise ValueError(f"Unknown kind: {kind}")
+
+        bus_values = bus_values[bus_values.index.get_level_values("carrier").isin(carriers)]
+        bus_values = (
+            remove_sector_buses(bus_values).groupby(["bus", "carrier"]).sum() if not bus_values.empty else bus_values
         )
 
-    # onshore regions
+        artifacts = _plot_capacity_on_ax(
+            n,
+            bus_values,
+            line_values,
+            link_values,
+            regions,
+            ax,
+            bus_scale=bus_scale,
+            line_scale=line_scale,
+        )
+        ax.set_title(f"{horizon}", fontsize=TITLE_SIZE)
+
+    # Attach a single shared legend on the rightmost axis.
+    if artifacts is not None:
+        _add_capacity_legends(
+            fig,
+            axes[-1],
+            artifacts["bus_colors"],
+            artifacts["nice_names"],
+            bus_scale,
+            line_scale,
+        )
+
+    kind_titles = {"base": "Base", "optimal": "Optimal", "new": "New"}
+    fig.suptitle(create_title(f"{kind_titles[kind]} Network Capacities by Horizon", **wildcards), fontsize=TITLE_SIZE)
+    fig.tight_layout(rect=[0, 0, 0.9, 0.97])
+    fig.savefig(save, bbox_inches="tight")
+    plt.close()
+
+
+def _bus_value_per_horizon(
+    n: pypsa.Network,
+    horizon,
+    series_t: pd.DataFrame,
+    aggregator: str = "mean",
+) -> pd.Series:
+    """Average (or sum) a time-indexed bus quantity over snapshots in `horizon`.
+
+    `series_t` columns are bus names; index is `n.snapshots` (MultiIndex of
+    (period, timestep) in the multi-investment case). When `horizon` is None,
+    aggregate over the entire snapshots index.
+    """
+    if horizon is None or not isinstance(series_t.index, pd.MultiIndex):
+        sub = series_t
+    else:
+        sub = series_t.loc[series_t.index.get_level_values(0) == horizon]
+    if aggregator == "sum":
+        return sub.sum(axis=0)
+    return sub.mean(axis=0)
+
+
+def _plot_choropleth_on_ax(
+    n: pypsa.Network,
+    values: pd.Series,
+    regions: gpd.GeoDataFrame,
+    ax,
+    cmap: str = "viridis",
+    vmin: float | None = None,
+    vmax: float | None = None,
+    show_lines: bool = True,
+) -> None:
+    """Draw a bus-value choropleth onto `ax`, joining `values` (indexed by bus) to `regions`."""
+    region_col = regions.set_index("name")
+    region_col = region_col.join(values.rename("value"))
+    region_col["value"] = region_col["value"].fillna(np.nan)
+
+    # Background for buses with no data: light gray.
     regions.plot(
         ax=ax,
         facecolor="whitesmoke",
         edgecolor="white",
         aspect="equal",
         transform=ccrs.PlateCarree(),
-        linewidth=1.2,
+        linewidth=0.5,
     )
+
+    region_col.plot(
+        column="value",
+        ax=ax,
+        cmap=cmap,
+        edgecolor="white",
+        linewidth=0.3,
+        aspect="equal",
+        transform=ccrs.PlateCarree(),
+        vmin=vmin,
+        vmax=vmax,
+        missing_kwds={"color": "whitesmoke"},
+    )
+
+    if show_lines and not n.lines.empty:
+        with plt.rc_context({"patch.linewidth": 0.05}):
+            n.plot(
+                bus_sizes=0,
+                line_widths=0.4,
+                link_widths=0,
+                line_colors="black",
+                ax=ax,
+                margin=0.2,
+                color_geomap=None,
+            )
+
     ax.set_extent(regions.total_bounds[[0, 2, 1, 3]])
-
-    legend_kwargs = {"loc": "upper left", "frameon": False}
-    bus_sizes = [5000, 10e3, 50e3]  # in MW
-    line_sizes = [2000, 5000]  # in MW
-
-    add_legend_circles(
-        ax,
-        [s / bus_scale for s in bus_sizes],
-        [f"{s / 1000:.0f} GW" for s in bus_sizes],
-        legend_kw={"bbox_to_anchor": (1, 1), "labelspacing": 3, **legend_kwargs},
-    )
-    add_legend_lines(
-        ax,
-        [s / line_scale for s in line_sizes],
-        [f"{s / 1000:.0f} GW" for s in line_sizes],
-        legend_kw={"bbox_to_anchor": (1, 0.8), **legend_kwargs},
-    )
-    add_legend_patches(
-        ax,
-        bus_colors,
-        nice_names,
-        legend_kw={"bbox_to_anchor": (1, 0), **legend_kwargs, "loc": "lower left"},
-    )
-    if not title:
-        ax.set_title("Capacity (MW)", fontsize=TITLE_SIZE, pad=20)
-    else:
-        ax.set_title(title, fontsize=TITLE_SIZE, pad=20)
-    fig.tight_layout()
-
-    return fig, ax
 
 
 def plot_demand_map(
@@ -310,79 +662,96 @@ def plot_demand_map(
     save: str,
     **wildcards,
 ) -> None:
-    """Plots map of network nodal demand."""
-    # get data
+    """Plot mean nodal demand as a region-tile choropleth, one subplot per horizon."""
+    horizons = _get_investment_periods(n)
 
-    bus_values = get_demand_base(n).mul(1e-3)
-    line_values = n.lines.s_nom
-    link_values = n.links[n.links.carrier == "AC"].p_nom.replace(to_replace={pd.NA: 0})
+    # AC-load (MW) at each bus per snapshot, summed across all loads at that bus.
+    load_per_bus = n.loads_t.p_set.rename(columns=n.loads.bus).T.groupby(level=0).sum().T
 
-    # plot data
-    title = create_title("Network Demand", **wildcards)
-    interconnect = wildcards.get("interconnect", None)
-    bus_scale = get_bus_scale(interconnect) if interconnect else 1
-    line_scale = get_line_scale(interconnect) if interconnect else 1
+    # Compute a shared color scale across horizons so subplots are comparable.
+    horizon_values = {h: _bus_value_per_horizon(n, h, load_per_bus, aggregator="mean") for h in horizons}
+    finite_vals = pd.concat(horizon_values.values()).replace([np.inf, -np.inf], np.nan).dropna()
+    vmin = float(finite_vals.min()) if not finite_vals.empty else 0.0
+    vmax = float(finite_vals.max()) if not finite_vals.empty else 1.0
 
-    fig, ax = plt.subplots(
-        figsize=(10, 10),
+    n_h = len(horizons)
+    fig, axes = plt.subplots(
+        1,
+        n_h,
+        figsize=(8 * n_h, 8.5),
         subplot_kw={"projection": ccrs.EqualEarth(n.buses.x.mean())},
     )
+    if n_h == 1:
+        axes = [axes]
 
-    line_width = line_values / line_scale
-    link_width = link_values / line_scale
+    for ax, horizon in zip(axes, horizons):
+        values = horizon_values[horizon]
+        _plot_choropleth_on_ax(n, values, regions, ax, cmap="viridis", vmin=vmin, vmax=vmax)
+        h_label = "" if horizon is None else f" — {horizon}"
+        ax.set_title(f"Mean Nodal Demand (MW){h_label}", fontsize=TITLE_SIZE - 2)
 
-    with plt.rc_context({"patch.linewidth": 0.1}):
-        n.plot(
-            bus_sizes=bus_values / bus_scale,
-            # bus_colors=None,
-            bus_alpha=0.7,
-            line_widths=line_width,
-            link_widths=0 if link_width.empty else link_width,
-            line_colors="teal",
-            ax=ax,
-            margin=0.2,
-            color_geomap=None,
-        )
+    # Shared colorbar on the right edge.
+    sm = plt.cm.ScalarMappable(cmap="viridis", norm=Normalize(vmin=vmin, vmax=vmax))
+    sm.set_array([])
+    cbar = fig.colorbar(sm, ax=axes, orientation="vertical", fraction=0.025, pad=0.02)
+    cbar.set_label("Mean Demand (MW)")
 
-    # onshore regions
-    regions.plot(
-        ax=ax,
-        facecolor="whitesmoke",
-        edgecolor="white",
-        aspect="equal",
-        transform=ccrs.PlateCarree(),
-        linewidth=1.2,
-    )
-    ax.set_extent(regions.total_bounds[[0, 2, 1, 3]])
+    fig.suptitle(create_title("Mean Nodal Demand by Horizon", **wildcards), fontsize=TITLE_SIZE)
+    fig.savefig(save, bbox_inches="tight")
+    plt.close()
 
-    legend_kwargs = {"loc": "upper left", "frameon": False}
-    bus_sizes = [5000, 10e3, 50e3]  # in MW
-    line_sizes = [2000, 5000]  # in MW
 
-    add_legend_circles(
-        ax,
-        [s / bus_scale for s in bus_sizes],
-        [f"{s / 1000:.0f} GW" for s in bus_sizes],
-        legend_kw={"bbox_to_anchor": (1, 1), "labelspacing": 3, **legend_kwargs},
-    )
-    add_legend_lines(
-        ax,
-        [s / line_scale for s in line_sizes],
-        [f"{s / 1000:.0f} GW" for s in line_sizes],
-        legend_kw={"bbox_to_anchor": (1, 0.8), **legend_kwargs},
-    )
-    add_legend_patches(
-        ax,
-        n.carriers.color.fillna("#000000"),
-        n.carriers.nice_name,
-        legend_kw={"bbox_to_anchor": (1, 0), **legend_kwargs, "loc": "lower left"},
-    )
-    if not title:
-        ax.set_title("Total Annual Demand (MW)", fontsize=TITLE_SIZE, pad=20)
+def plot_lmp_choropleth_map(
+    n: pypsa.Network,
+    regions: gpd.GeoDataFrame,
+    save: str,
+    **wildcards,
+) -> None:
+    """Plot mean nodal LMP as a region-tile choropleth, one subplot per horizon."""
+    if not hasattr(n, "buses_t") or "marginal_price" not in n.buses_t or n.buses_t.marginal_price.empty:
+        logger.warning("No marginal_price data available; skipping LMP map.")
+        fig, ax = plt.subplots(figsize=(10, 10))
+        ax.text(0.5, 0.5, "No LMP data available", ha="center", va="center", fontsize=14)
+        ax.axis("off")
+        fig.savefig(save)
+        plt.close()
+        return
+
+    horizons = _get_investment_periods(n)
+    lmps_t = n.buses_t.marginal_price
+
+    horizon_values = {h: _bus_value_per_horizon(n, h, lmps_t, aggregator="mean") for h in horizons}
+    finite_vals = pd.concat(horizon_values.values()).replace([np.inf, -np.inf], np.nan).dropna()
+    if finite_vals.empty:
+        vmin, vmax = 0.0, 1.0
     else:
-        ax.set_title(title, fontsize=TITLE_SIZE, pad=20)
-    fig.tight_layout()
-    fig.savefig(save)
+        # Clip extreme outliers for color stability (5th/95th pct).
+        vmin = float(np.nanpercentile(finite_vals.values, 5))
+        vmax = float(np.nanpercentile(finite_vals.values, 95))
+
+    n_h = len(horizons)
+    fig, axes = plt.subplots(
+        1,
+        n_h,
+        figsize=(8 * n_h, 8.5),
+        subplot_kw={"projection": ccrs.EqualEarth(n.buses.x.mean())},
+    )
+    if n_h == 1:
+        axes = [axes]
+
+    for ax, horizon in zip(axes, horizons):
+        values = horizon_values[horizon]
+        _plot_choropleth_on_ax(n, values, regions, ax, cmap="plasma", vmin=vmin, vmax=vmax)
+        h_label = "" if horizon is None else f" — {horizon}"
+        ax.set_title(f"Mean LMP ($/MWh){h_label}", fontsize=TITLE_SIZE - 2)
+
+    sm = plt.cm.ScalarMappable(cmap="plasma", norm=Normalize(vmin=vmin, vmax=vmax))
+    sm.set_array([])
+    cbar = fig.colorbar(sm, ax=axes, orientation="vertical", fraction=0.025, pad=0.02)
+    cbar.set_label("Mean LMP ($/MWh)")
+
+    fig.suptitle(create_title("Mean Locational Marginal Price by Horizon", **wildcards), fontsize=TITLE_SIZE)
+    fig.savefig(save, bbox_inches="tight")
     plt.close()
 
 
@@ -393,35 +762,8 @@ def plot_base_capacity_map(
     save: str,
     **wildcards,
 ) -> None:
-    """Plots map of base network capacities."""
-    # get data
-
-    bus_values = get_capacity_base(n)
-    bus_values = bus_values[bus_values.index.get_level_values(1).isin(carriers)]
-    bus_values = remove_sector_buses(bus_values).groupby(by=["bus", "carrier"]).sum()
-
-    line_values = n.lines.s_nom
-    link_values = n.links[n.links.carrier == "AC"].p_nom.replace(to_replace={pd.NA: 0})
-
-    # plot data
-
-    title = create_title("Base Network Capacities", **wildcards)
-    interconnect = wildcards.get("interconnect", None)
-    bus_scale = get_bus_scale(interconnect) if interconnect else 1
-    line_scale = get_line_scale(interconnect) if interconnect else 1
-
-    fig, _ = plot_capacity_map(
-        n=n,
-        bus_values=bus_values,
-        line_values=line_values,
-        link_values=link_values,
-        regions=regions,
-        line_scale=line_scale,
-        bus_scale=bus_scale,
-        title=title,
-    )
-    fig.savefig(save)
-    plt.close()
+    """Plot installed (base) capacity active in each planning horizon."""
+    plot_capacity_map_by_horizon(n, regions, carriers, save, kind="base", **wildcards)
 
 
 def plot_opt_capacity_map(
@@ -431,38 +773,8 @@ def plot_opt_capacity_map(
     save: str,
     **wildcards,
 ) -> None:
-    """Plots map of optimal network capacities."""
-    # get data
-    # capacity = n.statistics()[['Optimal Capacity']]
-    # capacity = capacity[capacity.index.get_level_values(0).isin(['Generator', 'StorageUnit'])]
-    # capacity.index = capacity.index.droplevel(0)
-
-    bus_values = get_capacity_brownfield(n)
-    bus_values = bus_values[bus_values.index.get_level_values("carrier").isin(carriers)]
-    bus_values = remove_sector_buses(bus_values).reset_index().groupby(by=["bus", "carrier"]).sum().squeeze()
-    line_values = n.lines.s_nom_opt
-    link_values = n.links[n.links.carrier == "AC"].p_nom_opt.replace(
-        to_replace={pd.NA: 0},
-    )
-
-    # plot data
-    title = create_title("Optimal Network Capacities", **wildcards)
-    interconnect = wildcards.get("interconnect", None)
-    bus_scale = get_bus_scale(interconnect) if interconnect else 1
-    line_scale = get_line_scale(interconnect) if interconnect else 1
-
-    fig, _ = plot_capacity_map(
-        n=n,
-        bus_values=bus_values,
-        line_values=line_values,
-        link_values=link_values,
-        regions=regions,
-        line_scale=line_scale,
-        bus_scale=bus_scale,
-        title=title,
-    )
-    fig.savefig(save)
-    plt.close()
+    """Plot optimal (brownfield) capacity active in each planning horizon."""
+    plot_capacity_map_by_horizon(n, regions, carriers, save, kind="optimal", **wildcards)
 
 
 def plot_new_capacity_map(
@@ -472,53 +784,8 @@ def plot_new_capacity_map(
     save: str,
     **wildcards,
 ) -> None:
-    """Plots map of new capacity."""
-    bus_pnom = get_capacity_base(n)
-    bus_pnom_opt = get_capacity_brownfield(n)
-
-    bus_values = bus_pnom_opt - bus_pnom
-    bus_values = bus_values[(bus_values > 0) & (bus_values.index.get_level_values(1).isin(carriers))]
-    bus_values = remove_sector_buses(bus_values).reset_index().groupby(by=["bus", "carrier"]).sum().squeeze()
-
-    title = create_title("New Network Capacities", **wildcards)
-
-    # n.plot() calls np.nanmin over bus coords; an empty bus_values yields an
-    # empty array and crashes the bbox computation. Save a placeholder instead.
-    if bus_values.empty:
-        logger.warning("No new capacity for carriers %s; saving placeholder map.", carriers)
-        fig, ax = plt.subplots(figsize=(10, 10))
-        ax.text(0.5, 0.5, "No new capacity built", ha="center", va="center", fontsize=14)
-        ax.set_title(title, fontsize=TITLE_SIZE, pad=20)
-        ax.axis("off")
-        fig.savefig(save)
-        plt.close()
-        return
-
-    line_snom = n.lines.s_nom
-    line_snom_opt = n.lines.s_nom_opt
-    line_values = line_snom_opt - line_snom
-
-    link_pnom = n.links[n.links.carrier == "AC"].p_nom
-    link_pnom_opt = n.links[n.links.carrier == "AC"].p_nom_opt
-    link_values = link_pnom_opt - link_pnom
-
-    # plot data
-    interconnect = wildcards.get("interconnect", None)
-    bus_scale = get_bus_scale(interconnect) if interconnect else 1
-    line_scale = get_line_scale(interconnect) if interconnect else 1
-
-    fig, _ = plot_capacity_map(
-        n=n,
-        bus_values=bus_values,
-        line_values=line_values,
-        link_values=link_values.replace(to_replace={pd.NA: 0}),
-        regions=regions,
-        line_scale=line_scale,
-        bus_scale=bus_scale,
-        title=title,
-    )
-    fig.savefig(save)
-    plt.close()
+    """Plot capacity newly built in each planning horizon (vintaged by build_year)."""
+    plot_capacity_map_by_horizon(n, regions, carriers, save, kind="new", **wildcards)
 
 
 def plot_renewable_potential(
@@ -687,4 +954,21 @@ if __name__ == "__main__":
         snakemake.output["renewable_potential_map.pdf"],
         **snakemake.wildcards,
     )
-    # plot_lmp_map(n, snakemake.output["lmp_map.pdf"], **snakemake.wildcards)
+    # `lmp_map.pdf` was added after the rule's outputs are sometimes cached in
+    # a stale DAG — fall back to skipping with a warning rather than crashing
+    # the whole rule. Force-recreate the DAG to pick it up: `snakemake -F` or
+    # remove the cached rule graph.
+    try:
+        lmp_save = snakemake.output["lmp_map.pdf"]
+    except (AttributeError, KeyError):
+        logger.warning(
+            "Output 'lmp_map.pdf' not registered in this rule invocation; "
+            "skipping LMP map. Force-rerun snakemake (e.g. with -F) to refresh outputs.",
+        )
+    else:
+        plot_lmp_choropleth_map(
+            n,
+            onshore_regions,
+            lmp_save,
+            **snakemake.wildcards,
+        )

--- a/workflow/scripts/plot_statistics.py
+++ b/workflow/scripts/plot_statistics.py
@@ -231,6 +231,15 @@ def plot_capacity_additions_bar(
     optimal_capacity.insert(0, "Existing", existing_capacity["Existing Capacity"])
     optimal_capacity = optimal_capacity.fillna(0)
 
+    # Drop the synthetic "imports" carrier — it represents external power
+    # injection (from trim_network or the imports/exports config), not built
+    # capacity, and would otherwise dominate the bar by orders of magnitude.
+    hidden_carriers = {"imports", "Imports"}
+    optimal_capacity = optimal_capacity.drop(
+        index=[c for c in hidden_carriers if c in optimal_capacity.index],
+        errors="ignore",
+    )
+
     stats = {"": optimal_capacity}
     variable = "Optimal Capacity"
     variable_units = " GW"

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -259,14 +259,32 @@ def run_optimize(n, rolling_horizon, skip_iterations, cf_solving, **kwargs):
 def freeze_prior_periods(n: pypsa.Network, prior_period: int):
     for c in n.components[["Generator", "Link", "StorageUnit", "Store"]]:
         attr = "e_nom" if c.name == "Store" else "p_nom"
-        c.static[attr] = c.static[attr + "_opt"]
-        # define  mask for existing resources that can be retired, and exclude them from the next line below
-        c.static.loc[c.static.build_year <= prior_period, attr + "_extendable"] = False
+
+        prior = c.static.build_year <= prior_period
+        retirable = prior & (c.static[attr + "_min"] == 0)
+
+        # lock in the optimized capacity from the prior period as the starting point
+        # for the next period — without this, p_nom still holds the pre-solve value
+        # (e.g. 0 for a new-build), so the next period's dispatch constraints would
+        # see the wrong installed capacity
+        c.static.loc[prior, attr] = c.static.loc[prior, attr + "_opt"]
+
+        # freeze all prior-period assets by default; the optimizer cannot add more
+        # capacity through assets that have already been built
+        c.static.loc[prior, attr + "_extendable"] = False
+
+        # assets with p_nom_min == 0 were extendable investment decisions (CCGT, OCGT,
+        # coal, EGS, wind, solar etc.) — the optimizer can retire them in future periods
+        # by shrinking p_nom down to zero; p_nom_max is capped at what was built so no
+        # new capacity can be added through this asset
+        c.static.loc[retirable, attr + "_extendable"] = True
+        c.static.loc[retirable, attr + "_max"] = c.static.loc[retirable, attr]
 
 
 # land use
+
 # transmissions
-# retirement mask
+
 # statistics
 
 # def prepare_brownfield(n, planning_horizon):

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -255,6 +255,31 @@ def run_optimize(n, rolling_horizon, skip_iterations, cf_solving, **kwargs):
         raise RuntimeError("Solving status 'infeasible'")
 
 
+def _stash_original_nominal(n: pypsa.Network) -> None:
+    """Snapshot the pre-solve p_nom / e_nom into `*_initial` once, on first call.
+
+    PyPSA's statistics use `n.df(c)[p_nom]` as the "installed" baseline. The
+    myopic freeze loop overwrites p_nom with p_nom_opt between horizons, which
+    erases the original baseline. Stashing it lets us restore it after the
+    final horizon so downstream tools can recover (p_nom_opt - p_nom_initial)
+    as "what was actually built across all horizons".
+    """
+    for c in n.iterate_components(["Generator", "Link", "StorageUnit", "Store"]):
+        attr = "e_nom" if c.name == "Store" else "p_nom"
+        col = f"{attr}_initial"
+        if col not in c.df.columns:
+            c.df[col] = c.df[attr]
+
+
+def _restore_original_nominal(n: pypsa.Network) -> None:
+    """Restore stashed pre-solve p_nom / e_nom so statistics see original baseline."""
+    for c in n.iterate_components(["Generator", "Link", "StorageUnit", "Store"]):
+        attr = "e_nom" if c.name == "Store" else "p_nom"
+        col = f"{attr}_initial"
+        if col in c.df.columns:
+            c.df[attr] = c.df[col]
+
+
 def freeze_prior_periods(n: pypsa.Network, prior_period: int):
     renewable_carriers = set(n.config["electricity"].get("renewable_carriers", []))
     for c in n.iterate_components(["Generator", "Link", "StorageUnit", "Store"]):
@@ -328,6 +353,7 @@ def solve_network(n, config, solving, opts="", **kwargs):
         case "perfect":
             run_optimize(n, rolling_horizon, skip_iterations, cf_solving, **kwargs)
         case "myopic":
+            _stash_original_nominal(n)
             for i, planning_horizon in enumerate(n.investment_periods):
                 sns_horizon = n.snapshots[n.snapshots.get_level_values(0) == planning_horizon]
                 kwargs["snapshots"] = sns_horizon
@@ -339,6 +365,11 @@ def solve_network(n, config, solving, opts="", **kwargs):
 
                 logger.info(f"Preparing brownfield from {planning_horizon}")
                 freeze_prior_periods(n, planning_horizon)
+            # Restore the pre-solve p_nom/e_nom baseline so downstream statistics
+            # and plots can compute (p_nom_opt - p_nom) = what was actually built
+            # across the myopic horizons. Without this, the inter-period freeze
+            # leaves p_nom == p_nom_opt and the "new capacity" signal is zero.
+            _restore_original_nominal(n)
         case _:
             raise ValueError(f"Invalid foresight option: '{foresight}'. Must be 'perfect' or 'myopic'.")
 

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -256,11 +256,19 @@ def run_optimize(n, rolling_horizon, skip_iterations, cf_solving, **kwargs):
 
 
 def freeze_prior_periods(n: pypsa.Network, prior_period: int):
+    renewable_carriers = set(n.config["electricity"].get("renewable_carriers", []))
     for c in n.components[["Generator", "Link", "StorageUnit", "Store"]]:
         attr = "e_nom" if c.name == "Store" else "p_nom"
 
         prior = c.static.build_year <= prior_period
-        retirable = prior & (c.static[attr + "_min"] == 0)
+        # Only assets explicitly tagged "existing" in their name (split out by
+        # attach_multihorizon_existing_generators in add_extra_components.py) AND
+        # not on a renewable carrier are eligible for economic retirement. Renewables
+        # attrite via lifetime, not economics, so they're excluded even if their name
+        # happens to match.
+        existing = c.static.index.str.contains("existing", case=False, na=False)
+        not_renewable = ~c.static["carrier"].isin(renewable_carriers)
+        retirable = prior & existing & not_renewable
 
         # lock in the optimized capacity from the prior period as the starting point
         # for the next period — without this, p_nom still holds the pre-solve value
@@ -272,10 +280,10 @@ def freeze_prior_periods(n: pypsa.Network, prior_period: int):
         # capacity through assets that have already been built
         c.static.loc[prior, attr + "_extendable"] = False
 
-        # assets with p_nom_min == 0 were extendable investment decisions (CCGT, OCGT,
-        # coal, EGS, wind, solar etc.) — the optimizer can retire them in future periods
-        # by shrinking p_nom down to zero; p_nom_max is capped at what was built so no
-        # new capacity can be added through this asset
+        # "existing" vintage assets carry p_nom_min=0 already (set by the split in
+        # add_extra_components.py), so flipping them back to extendable lets the
+        # optimizer retire them by shrinking p_nom toward zero; p_nom_max is capped
+        # at the locked-in capacity so no new capacity can be added through this asset
         c.static.loc[retirable, attr + "_extendable"] = True
         c.static.loc[retirable, attr + "_max"] = c.static.loc[retirable, attr]
 

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -24,7 +24,6 @@ Additionally, some extra constraints specified in :mod:`solve_network` are added
 """
 
 import logging
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -281,162 +280,6 @@ def freeze_prior_periods(n: pypsa.Network, prior_period: int):
         c.static.loc[retirable, attr + "_max"] = c.static.loc[retirable, attr]
 
 
-# land use
-
-# transmissions
-
-# statistics
-
-# def prepare_brownfield(n, planning_horizon):
-#     """Prepare the network for the next planning horizon by setting up brownfield constraints.
-#     Used for myopic foresight.
-
-#     This function:
-#     1. Sets minimum capacities for transmission lines and DC links
-#     2. Updates generator, link, and storage unit capacities
-#     3. Handles time-dependent data transfer between planning periods
-#     """
-#     # electric transmission grid set optimised capacities of previous as minimum
-#     n.lines.s_nom_min = n.lines.s_nom_opt  # for lines
-#     dc_i = n.links[n.links.carrier == "DC"].index
-#     n.links.loc[dc_i, "p_nom_min"] = n.links.loc[dc_i, "p_nom_opt"]  # for links
-
-#     for c in n.iterate_components(["Generator", "Link", "StorageUnit"]):
-#         nm = c.name
-#         # limit our components that we remove/modify to those prior to this time horizon
-#         c_lim = c.df.loc[n.get_active_assets(nm, planning_horizon)]
-
-#         logger.info(f"Preparing brownfield for the component {nm}")
-#         # attribute selection for naming convention
-#         attr = "p"
-#         # copy over asset sizing from previous period
-#         c_lim[f"{attr}_nom"] = c_lim[f"{attr}_nom_opt"]
-#         c_lim[f"{attr}_nom_extendable"] = False
-#         df = copy.deepcopy(c_lim)
-#         time_df = copy.deepcopy(c.pnl)
-
-#         for c_idx in c_lim.index:
-#             n.remove(nm, c_idx)
-
-#         for df_idx in df.index:
-#             if nm == "Generator":
-#                 n.madd(
-#                     nm,
-#                     [df_idx],
-#                     carrier=df.loc[df_idx].carrier,
-#                     bus=df.loc[df_idx].bus,
-#                     p_nom_min=df.loc[df_idx].p_nom_min,
-#                     p_nom=df.loc[df_idx].p_nom,
-#                     p_nom_max=df.loc[df_idx].p_nom_max,
-#                     p_nom_extendable=df.loc[df_idx].p_nom_extendable,
-#                     ramp_limit_up=df.loc[df_idx].ramp_limit_up,
-#                     ramp_limit_down=df.loc[df_idx].ramp_limit_down,
-#                     efficiency=df.loc[df_idx].efficiency,
-#                     marginal_cost=df.loc[df_idx].marginal_cost,
-#                     capital_cost=df.loc[df_idx].capital_cost,
-#                     build_year=df.loc[df_idx].build_year,
-#                     lifetime=df.loc[df_idx].lifetime,
-#                     heat_rate=df.loc[df_idx].heat_rate,
-#                     fuel_cost=df.loc[df_idx].fuel_cost,
-#                     vom_cost=df.loc[df_idx].vom_cost,
-#                     carrier_base=df.loc[df_idx].carrier_base,
-#                     p_min_pu=df.loc[df_idx].p_min_pu,
-#                     p_max_pu=df.loc[df_idx].p_max_pu,
-#                     land_region=df.loc[df_idx].land_region,
-#                 )
-#             else:
-#                 n.add(nm, df_idx, **df.loc[df_idx])
-#         logger.info(n.consistency_check())
-
-#         # copy time-dependent
-#         selection = n.component_attrs[nm].type.str.contains("series")
-#         for tattr in n.component_attrs[nm].index[selection]:
-#             n.import_series_from_dataframe(time_df[tattr], nm, tattr)
-
-#     # roll over the last snapshot of time varying storage state of charge to be the state_of_charge_initial for the next time period
-#     n.storage_units.loc[:, "state_of_charge_initial"] = n.storage_units_t.state_of_charge.loc[planning_horizon].iloc[-1]
-
-
-# def mask_future_generators(n, planning_horizon):
-#     """Disable generators whose vintage year hasn't been reached yet.
-
-#     In myopic mode (multi_investment_periods=False) PyPSA does not use
-#     build_year to restrict dispatch, so all vintages are available in every
-#     period solve. This function zeros out capacity for future-vintage
-#     generators before a period solve so they cannot be built or dispatched.
-
-#     Returns saved state needed by restore_future_generators.
-#     """
-#     future_gens = n.generators.index[
-#         n.generators["build_year"].notna() & (n.generators["build_year"] > planning_horizon)
-#     ]
-#     if future_gens.empty:
-#         return future_gens, None, None, None, None
-#     saved_extendable = n.generators.loc[future_gens, "p_nom_extendable"].copy()
-#     saved_p_nom_max = n.generators.loc[future_gens, "p_nom_max"].copy()
-#     saved_p_nom = n.generators.loc[future_gens, "p_nom"].copy()
-#     saved_p_nom_min = n.generators.loc[future_gens, "p_nom_min"].copy()
-#     n.generators.loc[future_gens, "p_nom_extendable"] = False
-#     n.generators.loc[future_gens, "p_nom_max"] = 0.0
-#     n.generators.loc[future_gens, "p_nom"] = 0.0
-#     n.generators.loc[future_gens, "p_nom_min"] = 0.0
-#     return future_gens, saved_extendable, saved_p_nom_max, saved_p_nom, saved_p_nom_min
-
-
-# def restore_future_generators(
-#     n,
-#     future_gens,
-#     saved_extendable,
-#     saved_p_nom_max,
-#     saved_p_nom=None,
-#     saved_p_nom_min=None,
-# ):
-#     """Restore generator parameters masked by mask_future_generators."""
-#     if future_gens.empty:
-#         return
-#     n.generators.loc[future_gens, "p_nom_extendable"] = saved_extendable
-#     n.generators.loc[future_gens, "p_nom_max"] = saved_p_nom_max
-#     if saved_p_nom is not None:
-#         n.generators.loc[future_gens, "p_nom"] = saved_p_nom
-#     if saved_p_nom_min is not None:
-#         n.generators.loc[future_gens, "p_nom_min"] = saved_p_nom_min
-
-
-# def update_egs_p_nom_max(n, planning_horizon):
-#     """Cap EGS p_nom_max for the current period by subtracting capacity already
-#     built in prior periods.
-
-#     In perfect foresight mode PyPSA treats p_nom_max as a shared resource
-#     across all investment periods. In myopic mode every period starts with the
-#     full supply-curve p_nom_max, so without this adjustment the optimizer can
-#     build the entire resource in the first period and then again in each
-#     subsequent period, far exceeding the actual geological potential.
-
-#     This function is called after mask_future_generators so that only
-#     non-extendable (locked-in) prior-period EGS generators are counted;
-#     masked future generators also have p_nom_extendable=False but start with
-#     p_nom=0 and therefore contribute nothing to the already-built total.
-#     """
-#     current_egs = n.generators.index[
-#         n.generators["carrier"].str.contains("EGS", case=False)
-#         & n.generators["p_nom_extendable"]
-#         & (n.generators["build_year"] == planning_horizon)
-#     ]
-#     if current_egs.empty:
-#         return
-
-#     locked_egs = n.generators[
-#         n.generators["carrier"].str.contains("EGS", case=False) & ~n.generators["p_nom_extendable"]
-#     ]
-#     locked_by_bus = locked_egs.groupby("bus")["p_nom"].sum()
-
-#     for gen_idx in current_egs:
-#         bus = n.generators.loc[gen_idx, "bus"]
-#         already_built = locked_by_bus.get(bus, 0.0)
-#         original_max = n.generators.loc[gen_idx, "p_nom_max"]
-#         n.generators.loc[gen_idx, "p_nom_max"] = max(0.0, original_max - already_built)
-
-
 def solve_network(n, config, solving, opts="", **kwargs):
     set_of_options = solving["solver"]["options"]
     cf_solving = solving["options"]
@@ -477,74 +320,17 @@ def solve_network(n, config, solving, opts="", **kwargs):
         case "perfect":
             run_optimize(n, rolling_horizon, skip_iterations, cf_solving, **kwargs)
         case "myopic":
-            # Checkpoint: save network state after each period's brownfield prep so a
-            # failed run can resume from the last completed period rather than scratch.
-            output_path = Path(snakemake.output[0])
-
-            def _checkpoint_path(horizon):
-                return output_path.parent / f"{output_path.stem}_checkpoint_{horizon}.nc"
-
-            def _period_path(horizon):
-                return output_path.parent / f"{output_path.stem}_period_{horizon}.nc"
-
-            # Find and load the latest available checkpoint
-            resume_after = None
-            for ph in reversed(list(n.investment_periods)):
-                cp = _checkpoint_path(ph)
-                if cp.exists():
-                    logger.info(f"Resuming from checkpoint: {cp}")
-                    n = pypsa.Network(str(cp))
-                    n.config = config
-                    n.opts = opts
-                    resume_after = ph
-                    break
-
             for i, planning_horizon in enumerate(n.investment_periods):
-                if resume_after is not None and planning_horizon <= resume_after:
-                    logger.info(f"Skipping {planning_horizon} — already completed in prior run")
-                    continue
-
                 sns_horizon = n.snapshots[n.snapshots.get_level_values(0) == planning_horizon]
                 kwargs["snapshots"] = sns_horizon
 
-                # future_gens, saved_extendable, saved_p_nom_max, saved_p_nom, saved_p_nom_min = mask_future_generators(
-                #     n,
-                #     planning_horizon,
-                # )
                 if "TCT" in opts:
                     apply_forced_retirements(n, planning_horizon, config)
-                # update_egs_p_nom_max(n, planning_horizon)
+
                 run_optimize(n, rolling_horizon, skip_iterations, cf_solving, **kwargs)
-                # restore_future_generators(
-                #     n,
-                #     future_gens,
-                #     saved_extendable,
-                #     saved_p_nom_max,
-                #     saved_p_nom,
-                #     saved_p_nom_min,
-                # )
-
-                # Save per-period network before prepare_brownfield modifies p_nom.
-                # plot_statistics reads these to get correct installed capacity per period.
-                pnc = _period_path(planning_horizon)
-                logger.info(f"Saving period network to {pnc}")
-                n.export_to_netcdf(str(pnc))
-
-                if i == len(n.investment_periods) - 1:
-                    logger.info(f"Final time horizon {planning_horizon}")
-                    for ph in n.investment_periods:
-                        cp = _checkpoint_path(ph)
-                        if cp.exists():
-                            cp.unlink()
-                            logger.info(f"Deleted checkpoint {cp}")
-                    continue
 
                 logger.info(f"Preparing brownfield from {planning_horizon}")
                 freeze_prior_periods(n, planning_horizon)
-                cp = _checkpoint_path(planning_horizon)
-                logger.info(f"Saving checkpoint to {cp}")
-                n.export_to_netcdf(str(cp))
-
         case _:
             raise ValueError(f"Invalid foresight option: '{foresight}'. Must be 'perfect' or 'myopic'.")
 

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -23,7 +23,6 @@ Additionally, some extra constraints specified in :mod:`solve_network` are added
     based on the rule :mod:`solve_network`.
 """
 
-import copy
 import logging
 from pathlib import Path
 
@@ -257,154 +256,167 @@ def run_optimize(n, rolling_horizon, skip_iterations, cf_solving, **kwargs):
         raise RuntimeError("Solving status 'infeasible'")
 
 
-def prepare_brownfield(n, planning_horizon):
-    """Prepare the network for the next planning horizon by setting up brownfield constraints.
-    Used for myopic foresight.
-
-    This function:
-    1. Sets minimum capacities for transmission lines and DC links
-    2. Updates generator, link, and storage unit capacities
-    3. Handles time-dependent data transfer between planning periods
-    """
-    # electric transmission grid set optimised capacities of previous as minimum
-    n.lines.s_nom_min = n.lines.s_nom_opt  # for lines
-    dc_i = n.links[n.links.carrier == "DC"].index
-    n.links.loc[dc_i, "p_nom_min"] = n.links.loc[dc_i, "p_nom_opt"]  # for links
-
-    for c in n.iterate_components(["Generator", "Link", "StorageUnit"]):
-        nm = c.name
-        # limit our components that we remove/modify to those prior to this time horizon
-        c_lim = c.df.loc[n.get_active_assets(nm, planning_horizon)]
-
-        logger.info(f"Preparing brownfield for the component {nm}")
-        # attribute selection for naming convention
-        attr = "p"
-        # copy over asset sizing from previous period
-        c_lim[f"{attr}_nom"] = c_lim[f"{attr}_nom_opt"]
-        c_lim[f"{attr}_nom_extendable"] = False
-        df = copy.deepcopy(c_lim)
-        time_df = copy.deepcopy(c.pnl)
-
-        for c_idx in c_lim.index:
-            n.remove(nm, c_idx)
-
-        for df_idx in df.index:
-            if nm == "Generator":
-                n.madd(
-                    nm,
-                    [df_idx],
-                    carrier=df.loc[df_idx].carrier,
-                    bus=df.loc[df_idx].bus,
-                    p_nom_min=df.loc[df_idx].p_nom_min,
-                    p_nom=df.loc[df_idx].p_nom,
-                    p_nom_max=df.loc[df_idx].p_nom_max,
-                    p_nom_extendable=df.loc[df_idx].p_nom_extendable,
-                    ramp_limit_up=df.loc[df_idx].ramp_limit_up,
-                    ramp_limit_down=df.loc[df_idx].ramp_limit_down,
-                    efficiency=df.loc[df_idx].efficiency,
-                    marginal_cost=df.loc[df_idx].marginal_cost,
-                    capital_cost=df.loc[df_idx].capital_cost,
-                    build_year=df.loc[df_idx].build_year,
-                    lifetime=df.loc[df_idx].lifetime,
-                    heat_rate=df.loc[df_idx].heat_rate,
-                    fuel_cost=df.loc[df_idx].fuel_cost,
-                    vom_cost=df.loc[df_idx].vom_cost,
-                    carrier_base=df.loc[df_idx].carrier_base,
-                    p_min_pu=df.loc[df_idx].p_min_pu,
-                    p_max_pu=df.loc[df_idx].p_max_pu,
-                    land_region=df.loc[df_idx].land_region,
-                )
-            else:
-                n.add(nm, df_idx, **df.loc[df_idx])
-        logger.info(n.consistency_check())
-
-        # copy time-dependent
-        selection = n.component_attrs[nm].type.str.contains("series")
-        for tattr in n.component_attrs[nm].index[selection]:
-            n.import_series_from_dataframe(time_df[tattr], nm, tattr)
-
-    # roll over the last snapshot of time varying storage state of charge to be the state_of_charge_initial for the next time period
-    n.storage_units.loc[:, "state_of_charge_initial"] = n.storage_units_t.state_of_charge.loc[planning_horizon].iloc[-1]
+def freeze_prior_periods(n: pypsa.Network, prior_period: int):
+    for c in n.components[["Generator", "Link", "StorageUnit", "Store"]]:
+        attr = "e_nom" if c.name == "Store" else "p_nom"
+        c.static[attr] = c.static[attr + "_opt"]
+        # define  mask for existing resources that can be retired, and exclude them from the next line below
+        c.static.loc[c.static.build_year <= prior_period, attr + "_extendable"] = False
 
 
-def mask_future_generators(n, planning_horizon):
-    """Disable generators whose vintage year hasn't been reached yet.
+# land use
+# transmissions
+# retirement mask
+# statistics
 
-    In myopic mode (multi_investment_periods=False) PyPSA does not use
-    build_year to restrict dispatch, so all vintages are available in every
-    period solve. This function zeros out capacity for future-vintage
-    generators before a period solve so they cannot be built or dispatched.
+# def prepare_brownfield(n, planning_horizon):
+#     """Prepare the network for the next planning horizon by setting up brownfield constraints.
+#     Used for myopic foresight.
 
-    Returns saved state needed by restore_future_generators.
-    """
-    future_gens = n.generators.index[
-        n.generators["build_year"].notna() & (n.generators["build_year"] > planning_horizon)
-    ]
-    if future_gens.empty:
-        return future_gens, None, None, None, None
-    saved_extendable = n.generators.loc[future_gens, "p_nom_extendable"].copy()
-    saved_p_nom_max = n.generators.loc[future_gens, "p_nom_max"].copy()
-    saved_p_nom = n.generators.loc[future_gens, "p_nom"].copy()
-    saved_p_nom_min = n.generators.loc[future_gens, "p_nom_min"].copy()
-    n.generators.loc[future_gens, "p_nom_extendable"] = False
-    n.generators.loc[future_gens, "p_nom_max"] = 0.0
-    n.generators.loc[future_gens, "p_nom"] = 0.0
-    n.generators.loc[future_gens, "p_nom_min"] = 0.0
-    return future_gens, saved_extendable, saved_p_nom_max, saved_p_nom, saved_p_nom_min
+#     This function:
+#     1. Sets minimum capacities for transmission lines and DC links
+#     2. Updates generator, link, and storage unit capacities
+#     3. Handles time-dependent data transfer between planning periods
+#     """
+#     # electric transmission grid set optimised capacities of previous as minimum
+#     n.lines.s_nom_min = n.lines.s_nom_opt  # for lines
+#     dc_i = n.links[n.links.carrier == "DC"].index
+#     n.links.loc[dc_i, "p_nom_min"] = n.links.loc[dc_i, "p_nom_opt"]  # for links
+
+#     for c in n.iterate_components(["Generator", "Link", "StorageUnit"]):
+#         nm = c.name
+#         # limit our components that we remove/modify to those prior to this time horizon
+#         c_lim = c.df.loc[n.get_active_assets(nm, planning_horizon)]
+
+#         logger.info(f"Preparing brownfield for the component {nm}")
+#         # attribute selection for naming convention
+#         attr = "p"
+#         # copy over asset sizing from previous period
+#         c_lim[f"{attr}_nom"] = c_lim[f"{attr}_nom_opt"]
+#         c_lim[f"{attr}_nom_extendable"] = False
+#         df = copy.deepcopy(c_lim)
+#         time_df = copy.deepcopy(c.pnl)
+
+#         for c_idx in c_lim.index:
+#             n.remove(nm, c_idx)
+
+#         for df_idx in df.index:
+#             if nm == "Generator":
+#                 n.madd(
+#                     nm,
+#                     [df_idx],
+#                     carrier=df.loc[df_idx].carrier,
+#                     bus=df.loc[df_idx].bus,
+#                     p_nom_min=df.loc[df_idx].p_nom_min,
+#                     p_nom=df.loc[df_idx].p_nom,
+#                     p_nom_max=df.loc[df_idx].p_nom_max,
+#                     p_nom_extendable=df.loc[df_idx].p_nom_extendable,
+#                     ramp_limit_up=df.loc[df_idx].ramp_limit_up,
+#                     ramp_limit_down=df.loc[df_idx].ramp_limit_down,
+#                     efficiency=df.loc[df_idx].efficiency,
+#                     marginal_cost=df.loc[df_idx].marginal_cost,
+#                     capital_cost=df.loc[df_idx].capital_cost,
+#                     build_year=df.loc[df_idx].build_year,
+#                     lifetime=df.loc[df_idx].lifetime,
+#                     heat_rate=df.loc[df_idx].heat_rate,
+#                     fuel_cost=df.loc[df_idx].fuel_cost,
+#                     vom_cost=df.loc[df_idx].vom_cost,
+#                     carrier_base=df.loc[df_idx].carrier_base,
+#                     p_min_pu=df.loc[df_idx].p_min_pu,
+#                     p_max_pu=df.loc[df_idx].p_max_pu,
+#                     land_region=df.loc[df_idx].land_region,
+#                 )
+#             else:
+#                 n.add(nm, df_idx, **df.loc[df_idx])
+#         logger.info(n.consistency_check())
+
+#         # copy time-dependent
+#         selection = n.component_attrs[nm].type.str.contains("series")
+#         for tattr in n.component_attrs[nm].index[selection]:
+#             n.import_series_from_dataframe(time_df[tattr], nm, tattr)
+
+#     # roll over the last snapshot of time varying storage state of charge to be the state_of_charge_initial for the next time period
+#     n.storage_units.loc[:, "state_of_charge_initial"] = n.storage_units_t.state_of_charge.loc[planning_horizon].iloc[-1]
 
 
-def restore_future_generators(
-    n,
-    future_gens,
-    saved_extendable,
-    saved_p_nom_max,
-    saved_p_nom=None,
-    saved_p_nom_min=None,
-):
-    """Restore generator parameters masked by mask_future_generators."""
-    if future_gens.empty:
-        return
-    n.generators.loc[future_gens, "p_nom_extendable"] = saved_extendable
-    n.generators.loc[future_gens, "p_nom_max"] = saved_p_nom_max
-    if saved_p_nom is not None:
-        n.generators.loc[future_gens, "p_nom"] = saved_p_nom
-    if saved_p_nom_min is not None:
-        n.generators.loc[future_gens, "p_nom_min"] = saved_p_nom_min
+# def mask_future_generators(n, planning_horizon):
+#     """Disable generators whose vintage year hasn't been reached yet.
+
+#     In myopic mode (multi_investment_periods=False) PyPSA does not use
+#     build_year to restrict dispatch, so all vintages are available in every
+#     period solve. This function zeros out capacity for future-vintage
+#     generators before a period solve so they cannot be built or dispatched.
+
+#     Returns saved state needed by restore_future_generators.
+#     """
+#     future_gens = n.generators.index[
+#         n.generators["build_year"].notna() & (n.generators["build_year"] > planning_horizon)
+#     ]
+#     if future_gens.empty:
+#         return future_gens, None, None, None, None
+#     saved_extendable = n.generators.loc[future_gens, "p_nom_extendable"].copy()
+#     saved_p_nom_max = n.generators.loc[future_gens, "p_nom_max"].copy()
+#     saved_p_nom = n.generators.loc[future_gens, "p_nom"].copy()
+#     saved_p_nom_min = n.generators.loc[future_gens, "p_nom_min"].copy()
+#     n.generators.loc[future_gens, "p_nom_extendable"] = False
+#     n.generators.loc[future_gens, "p_nom_max"] = 0.0
+#     n.generators.loc[future_gens, "p_nom"] = 0.0
+#     n.generators.loc[future_gens, "p_nom_min"] = 0.0
+#     return future_gens, saved_extendable, saved_p_nom_max, saved_p_nom, saved_p_nom_min
 
 
-def update_egs_p_nom_max(n, planning_horizon):
-    """Cap EGS p_nom_max for the current period by subtracting capacity already
-    built in prior periods.
+# def restore_future_generators(
+#     n,
+#     future_gens,
+#     saved_extendable,
+#     saved_p_nom_max,
+#     saved_p_nom=None,
+#     saved_p_nom_min=None,
+# ):
+#     """Restore generator parameters masked by mask_future_generators."""
+#     if future_gens.empty:
+#         return
+#     n.generators.loc[future_gens, "p_nom_extendable"] = saved_extendable
+#     n.generators.loc[future_gens, "p_nom_max"] = saved_p_nom_max
+#     if saved_p_nom is not None:
+#         n.generators.loc[future_gens, "p_nom"] = saved_p_nom
+#     if saved_p_nom_min is not None:
+#         n.generators.loc[future_gens, "p_nom_min"] = saved_p_nom_min
 
-    In perfect foresight mode PyPSA treats p_nom_max as a shared resource
-    across all investment periods. In myopic mode every period starts with the
-    full supply-curve p_nom_max, so without this adjustment the optimizer can
-    build the entire resource in the first period and then again in each
-    subsequent period, far exceeding the actual geological potential.
 
-    This function is called after mask_future_generators so that only
-    non-extendable (locked-in) prior-period EGS generators are counted;
-    masked future generators also have p_nom_extendable=False but start with
-    p_nom=0 and therefore contribute nothing to the already-built total.
-    """
-    current_egs = n.generators.index[
-        n.generators["carrier"].str.contains("EGS", case=False)
-        & n.generators["p_nom_extendable"]
-        & (n.generators["build_year"] == planning_horizon)
-    ]
-    if current_egs.empty:
-        return
+# def update_egs_p_nom_max(n, planning_horizon):
+#     """Cap EGS p_nom_max for the current period by subtracting capacity already
+#     built in prior periods.
 
-    locked_egs = n.generators[
-        n.generators["carrier"].str.contains("EGS", case=False) & ~n.generators["p_nom_extendable"]
-    ]
-    locked_by_bus = locked_egs.groupby("bus")["p_nom"].sum()
+#     In perfect foresight mode PyPSA treats p_nom_max as a shared resource
+#     across all investment periods. In myopic mode every period starts with the
+#     full supply-curve p_nom_max, so without this adjustment the optimizer can
+#     build the entire resource in the first period and then again in each
+#     subsequent period, far exceeding the actual geological potential.
 
-    for gen_idx in current_egs:
-        bus = n.generators.loc[gen_idx, "bus"]
-        already_built = locked_by_bus.get(bus, 0.0)
-        original_max = n.generators.loc[gen_idx, "p_nom_max"]
-        n.generators.loc[gen_idx, "p_nom_max"] = max(0.0, original_max - already_built)
+#     This function is called after mask_future_generators so that only
+#     non-extendable (locked-in) prior-period EGS generators are counted;
+#     masked future generators also have p_nom_extendable=False but start with
+#     p_nom=0 and therefore contribute nothing to the already-built total.
+#     """
+#     current_egs = n.generators.index[
+#         n.generators["carrier"].str.contains("EGS", case=False)
+#         & n.generators["p_nom_extendable"]
+#         & (n.generators["build_year"] == planning_horizon)
+#     ]
+#     if current_egs.empty:
+#         return
+
+#     locked_egs = n.generators[
+#         n.generators["carrier"].str.contains("EGS", case=False) & ~n.generators["p_nom_extendable"]
+#     ]
+#     locked_by_bus = locked_egs.groupby("bus")["p_nom"].sum()
+
+#     for gen_idx in current_egs:
+#         bus = n.generators.loc[gen_idx, "bus"]
+#         already_built = locked_by_bus.get(bus, 0.0)
+#         original_max = n.generators.loc[gen_idx, "p_nom_max"]
+#         n.generators.loc[gen_idx, "p_nom_max"] = max(0.0, original_max - already_built)
 
 
 def solve_network(n, config, solving, opts="", **kwargs):
@@ -412,7 +424,7 @@ def solve_network(n, config, solving, opts="", **kwargs):
     cf_solving = solving["options"]
 
     foresight = snakemake.params.foresight
-    kwargs["multi_investment_periods"] = config["foresight"] == "perfect"
+    kwargs["multi_investment_periods"] = True
 
     kwargs["solver_options"] = solving["solver_options"][set_of_options] if set_of_options else {}
     kwargs["solver_name"] = solving["solver"]["name"]
@@ -477,22 +489,22 @@ def solve_network(n, config, solving, opts="", **kwargs):
                 sns_horizon = n.snapshots[n.snapshots.get_level_values(0) == planning_horizon]
                 kwargs["snapshots"] = sns_horizon
 
-                future_gens, saved_extendable, saved_p_nom_max, saved_p_nom, saved_p_nom_min = mask_future_generators(
-                    n,
-                    planning_horizon,
-                )
+                # future_gens, saved_extendable, saved_p_nom_max, saved_p_nom, saved_p_nom_min = mask_future_generators(
+                #     n,
+                #     planning_horizon,
+                # )
                 if "TCT" in opts:
                     apply_forced_retirements(n, planning_horizon, config)
-                update_egs_p_nom_max(n, planning_horizon)
+                # update_egs_p_nom_max(n, planning_horizon)
                 run_optimize(n, rolling_horizon, skip_iterations, cf_solving, **kwargs)
-                restore_future_generators(
-                    n,
-                    future_gens,
-                    saved_extendable,
-                    saved_p_nom_max,
-                    saved_p_nom,
-                    saved_p_nom_min,
-                )
+                # restore_future_generators(
+                #     n,
+                #     future_gens,
+                #     saved_extendable,
+                #     saved_p_nom_max,
+                #     saved_p_nom,
+                #     saved_p_nom_min,
+                # )
 
                 # Save per-period network before prepare_brownfield modifies p_nom.
                 # plot_statistics reads these to get correct installed capacity per period.
@@ -510,7 +522,7 @@ def solve_network(n, config, solving, opts="", **kwargs):
                     continue
 
                 logger.info(f"Preparing brownfield from {planning_horizon}")
-                prepare_brownfield(n, planning_horizon)
+                freeze_prior_periods(n, planning_horizon)
                 cp = _checkpoint_path(planning_horizon)
                 logger.info(f"Saving checkpoint to {cp}")
                 n.export_to_netcdf(str(cp))

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -257,35 +257,35 @@ def run_optimize(n, rolling_horizon, skip_iterations, cf_solving, **kwargs):
 
 def freeze_prior_periods(n: pypsa.Network, prior_period: int):
     renewable_carriers = set(n.config["electricity"].get("renewable_carriers", []))
-    for c in n.components[["Generator", "Link", "StorageUnit", "Store"]]:
+    for c in n.iterate_components(["Generator", "Link", "StorageUnit", "Store"]):
         attr = "e_nom" if c.name == "Store" else "p_nom"
 
-        prior = c.static.build_year <= prior_period
+        prior = c.df.build_year <= prior_period
         # Only assets explicitly tagged "existing" in their name (split out by
         # attach_multihorizon_existing_generators in add_extra_components.py) AND
         # not on a renewable carrier are eligible for economic retirement. Renewables
         # attrite via lifetime, not economics, so they're excluded even if their name
         # happens to match.
-        existing = c.static.index.str.contains("existing", case=False, na=False)
-        not_renewable = ~c.static["carrier"].isin(renewable_carriers)
+        existing = c.df.index.str.contains("existing", case=False, na=False)
+        not_renewable = ~c.df["carrier"].isin(renewable_carriers)
         retirable = prior & existing & not_renewable
 
         # lock in the optimized capacity from the prior period as the starting point
         # for the next period — without this, p_nom still holds the pre-solve value
         # (e.g. 0 for a new-build), so the next period's dispatch constraints would
         # see the wrong installed capacity
-        c.static.loc[prior, attr] = c.static.loc[prior, attr + "_opt"]
+        c.df.loc[prior, attr] = c.df.loc[prior, attr + "_opt"]
 
         # freeze all prior-period assets by default; the optimizer cannot add more
         # capacity through assets that have already been built
-        c.static.loc[prior, attr + "_extendable"] = False
+        c.df.loc[prior, attr + "_extendable"] = False
 
         # "existing" vintage assets carry p_nom_min=0 already (set by the split in
         # add_extra_components.py), so flipping them back to extendable lets the
         # optimizer retire them by shrinking p_nom toward zero; p_nom_max is capped
         # at the locked-in capacity so no new capacity can be added through this asset
-        c.static.loc[retirable, attr + "_extendable"] = True
-        c.static.loc[retirable, attr + "_max"] = c.static.loc[retirable, attr]
+        c.df.loc[retirable, attr + "_extendable"] = True
+        c.df.loc[retirable, attr + "_max"] = c.df.loc[retirable, attr]
 
 
 def solve_network(n, config, solving, opts="", **kwargs):

--- a/workflow/scripts/test/fixtures/build_test_network.py
+++ b/workflow/scripts/test/fixtures/build_test_network.py
@@ -111,7 +111,7 @@ def build():
             0.80,
             0.74,
             0.68,
-        ]
+        ],
     )
     load_profile = pd.Series(np.tile(hour_load, len(invest_periods)), index=sns)
 

--- a/workflow/scripts/test/test_reserves.py
+++ b/workflow/scripts/test/test_reserves.py
@@ -417,7 +417,7 @@ def test_erm_zero_emission_period_excludes_fossil(multi_period_reserve_network, 
             "regions": ["all", "all"],
             "planning_horizon": [2030, 2040],
             "limit": [1e9, 0],
-        }
+        },
     ).to_csv(co2_csv, index=False)
 
     n_zero = multi_period_reserve_network.copy()


### PR DESCRIPTION
## Summary

This PR bundles a set of fixes to the myopic foresight pipeline and the post-solve plotting/statistics that surfaced while running multi-horizon scenarios. Changes split into three groups:

### 1. Myopic optimization correctness (`solve_network.py`, `add_extra_components.py`, `add_sectors.py`)

- **Retirement / extendability handling rewrite.** The prior `freeze_prior_periods` flipped *every* prior-vintage asset with `p_nom_min == 0` to extendable, including renewables — which conflated lifetime-driven attrition with economic retirement. Now only assets explicitly tagged `"existing"` in the index (i.e. split out by `attach_multihorizon_existing_generators`) **and** on a non-renewable carrier are eligible for economic retirement. Renewables attrite via lifetime.
- **Stash & restore original nominal capacity.** Between horizons, `freeze_prior_periods` still overwrites `p_nom := p_nom_opt` so dispatch sees the locked installed capacity in the next horizon. But this used to silently destroy the pre-solve `p_nom` baseline — PyPSA statistics report `installed_capacity = p_nom`, so `optimal_capacity == installed_capacity` everywhere and `p_nom_opt - p_nom = 0` (no detectable new builds). Added `_stash_original_nominal` / `_restore_original_nominal` so the original `p_nom` is snapshotted once before the myopic loop and restored at the end. Downstream statistics and the new-capacity plots now produce real signal.
- **PyPSA 0.30.2 API fix.** `n.components[[...]]` list-subscript and `c.static` are PyPSA ≥ 1.0 API. Switched to `n.iterate_components([...])` / `c.df` to match the pinned PyPSA version.

### 2. Transmission vintaging (`cluster_network.py`)

- Stamp every transmission Line/Link added in `cluster_network` with `build_year = min(planning_horizons)` and `lifetime = 60` (matching HVAC/HVDC cost_recovery_period_years in `build_cost_data.py`).
- For each ITL fwd/rev link and the `p19_to_p20` patch, add vintaged duplicates at every planning horizon after the first (`p_nom=0`, `p_nom_extendable=False`). `prepare_network` flips these to extendable so myopic can build new transmission tagged with its own build_year.
- Defensive backstop after clustering for any Line/Link still on PyPSA defaults (covers upstream TAMU lines from `build_base_network`).

### 3. Plotting and statistics

- **Per-horizon capacity maps.** `plot_base_capacity_map`, `plot_opt_capacity_map`, and `plot_new_capacity_map` now produce one subplot per investment period showing what is built/active in each horizon. Multi-horizon active masks use `build_year ≤ horizon < build_year + lifetime`. "New" uses the stricter `build_year == horizon`. Single-horizon networks keep the original single-axis layout.
- **Choropleth demand map.** Replaced bubble-style nodal demand with a region-tile choropleth (joined on `regions.name == bus`), one subplot per horizon, shared color scale. Uses a truncated `Blues` palette starting at ~25% so the low end is a clearly visible light blue.
- **LMP choropleth map (new output).** Mean `marginal_price` per bus rendered as region tiles, per horizon, with 5–95 percentile color clipping for stability against extreme values. Added `lmp_map.pdf` to `FIGURES_MAPS` in `Snakefile`.
- **`plot_capacity_additions_bar` hides the `imports` carrier**, since it represents external power injection (from `trim_network` or the imports/exports config) and would otherwise dominate the bar.
- **Robustness fixes**: filter `bus_values` to carriers that have colors defined (fixes latent `Colors not defined for all elements` from `n.plot()`); handle empty `bus_values` (placeholder + region backdrop instead of `np.nanmin` crash on empty array); graceful fallback if `lmp_map.pdf` isn't in the snakemake job's outputs (stale DAG case).

### 4. Misc

- Add land constraint for EGS (`add_electricity.py`).
- Update `nrel_exclusion_v1` Zenodo record ID to `20316475`.

## Test plan

- [ ] Run `snakemake -F plot_network_maps` on a multi-horizon network (e.g. `config.small_mh.yaml`, 2030/2040/2050) and confirm:
  - [ ] `capacity_map_{base,optimized,new}.pdf` each contain one subplot per horizon
  - [ ] `demand_map.pdf` and `lmp_map.pdf` are choropleth tiles (not bubbles)
  - [ ] `capacity_additions_bar.pdf` does not contain an `imports` bar
- [ ] Inspect a solved `.nc` with `n.statistics.installed_capacity()` vs `optimal_capacity()` — they should differ where new capacity was built (no longer identical).
- [ ] For myopic with retirements enabled (`opts: ERM-...`), verify renewables are not flagged retirable while non-renewable `*existing*` generators are.
- [ ] Single-horizon scenarios (`foresight: perfect`) still render single-axis capacity maps unchanged.