### PR TITLE
Add EER electricity demand profile

### DIFF
--- a/ /policy.py
+++ b/ /policy.py
@@ -184,9 +184,9 @@ def add_technology_capacity_target_constraints(n, config):
             )
 
         if not np.isnan(target["max"]):
-            _RESIDUAL_TOL = 1.0  # MW — treat clustering residuals below this as zero
+            residual_tol = 1.0  # MW — treat clustering residuals below this as zero
             if target["max"] < lhs_existing:
-                if lhs_existing - target["max"] > _RESIDUAL_TOL:
+                if lhs_existing - target["max"] > residual_tol:
                     logger.warning(
                         f"TCT max of {target['max']} MW for {target['carrier']} in region {target['region']} "
                         f"is below existing non-extendable capacity of {lhs_existing:.1f} MW — "

--- a/ /policy.py
+++ b/ /policy.py
@@ -195,7 +195,7 @@ def add_technology_capacity_target_constraints(n, config):
                 else:
                     logger.warning(
                         f"TCT max of {target['max']} MW for {target['carrier']} is below existing "
-                        f"{lhs_existing:.4f} MW (within {_RESIDUAL_TOL} MW tolerance — treating as numerical residual)",
+                        f"{lhs_existing:.4f} MW (within {residual_tol} MW tolerance — treating as numerical residual)",
                     )
                 lhs_existing = target["max"]  # clamp so rhs = 0 in both cases
 

--- a/docs/source/configtables/electricity.csv
+++ b/docs/source/configtables/electricity.csv
@@ -23,6 +23,7 @@ profile,--,"One of {``efs``, ``eia``, ``eer``}","Datasource for electrical load 
 scenario:,,,
 -efs_case,--,"One of {``reference``, ``medium``, ``high``}",(UNDER DEVELOPMENT) Extracts EFS data according to level of adoption
 -efs_speed,--,"One of {``slow``, ``moderate``, ``fast``}",(UNDER DEVELOPMENT) Extracts EFS data according to speed of electrification
+-eer_file,--,"One of {``demand_EER2025_100by2050.h5``, ``demand_EER2025_Baseline_AEO2023.h5``, ``demand_EER2025_IRAlow.h5``}",Selects the EER demand dataset file to download and use when ``profile`` is ``eer``.
 -aeo,--,One of the AEO scenarios `here <https://www.eia.gov/outlooks/aeo/data/browser/>`_,(UNDER DEVELOPMENT) Scales future demand according to the AEO scenario
 ,,,
 demand_response:,,,Settings to activate and configure demand response

--- a/docs/source/configtables/electricity.csv
+++ b/docs/source/configtables/electricity.csv
@@ -19,7 +19,7 @@ Store,--,Any subset of {``battery``},Adds extendable storage units (battery and/
 Links,--,Any subset of {},Adds extendable linksat every connection where there are lines or HVDC links without capacity limits and with zero initial capacity. Hydrogen pipelines require hydrogen storage to be modelled as ``Store``.
 ,,,
 demand:,,,
-profile,--,"One of {``efs``, ``eia``}",Datasource for electrical load data. ``EFS`` pulls future state level electrical demand data. ``EIA`` pulls historical balancing level electrical demand dataa.
+profile,--,"One of {``efs``, ``eia``, ``eer``}","Datasource for electrical load data. ``EFS`` pulls future state level electrical demand data. ``EIA`` pulls historical balancing level electrical demand data. ``EER`` pulls future state-level profiles from the EER dataset; when selected, ``planning_horizons`` must be one of 2021, 2025, 2030, 2035, 2040, 2045, or 2050 and ``renewable_weather_years`` must contain exactly one year from 2007-2013 or 2016-2023."
 scenario:,,,
 -efs_case,--,"One of {``reference``, ``medium``, ``high``}",(UNDER DEVELOPMENT) Extracts EFS data according to level of adoption
 -efs_speed,--,"One of {``slow``, ``moderate``, ``fast``}",(UNDER DEVELOPMENT) Extracts EFS data according to speed of electrification

--- a/workflow/repo_data/config/config.default.yaml
+++ b/workflow/repo_data/config/config.default.yaml
@@ -83,7 +83,7 @@ electricity:
     Link: [] 
 
   demand: 
-    profile: efs # efs, eia
+    profile: efs # efs, eia, eer
     scenario: 
       efs_case: reference # reference, medium, high
       efs_speed: moderate # slow, moderate, rapid

--- a/workflow/repo_data/config/config.default.yaml
+++ b/workflow/repo_data/config/config.default.yaml
@@ -87,6 +87,7 @@ electricity:
     scenario: 
       efs_case: reference # reference, medium, high
       efs_speed: moderate # slow, moderate, rapid
+      eer_file: demand_EER2025_100by2050.h5 # demand_EER2025_100by2050.h5, demand_EER2025_Baseline_AEO2023.h5, demand_EER2025_IRAlow.h5
       aeo: reference
 
   demand_response:

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -290,6 +290,25 @@ INTERCONNECT_2_STATE["eastern"].extend(["NH", "NJ", "NY", "NC", "ND", "OH", "OK"
 INTERCONNECT_2_STATE["eastern"].extend(["RI", "SC", "SD", "TN", "VT", "VA", "WV", "WI"])
 INTERCONNECT_2_STATE["usa"] = sum(INTERCONNECT_2_STATE.values(), [])
 
+EER_DEMAND_FILES = (
+    "demand_EER2025_100by2050.h5",
+    "demand_EER2025_Baseline_AEO2023.h5",
+    "demand_EER2025_IRAlow.h5",
+)
+
+
+def eer_demand_file():
+    filename = config["electricity"]["demand"]["scenario"].get(
+        "eer_file",
+        "demand_EER2025_100by2050.h5",
+    )
+    if filename not in EER_DEMAND_FILES:
+        raise ValueError(
+            "electricity.demand.scenario.eer_file must be one of "
+            f"{EER_DEMAND_FILES}; received {filename}."
+        )
+    return filename
+
 
 def demand_raw_data(wildcards):
     # get profile to use
@@ -321,7 +340,7 @@ def demand_raw_data(wildcards):
         ].capitalize()
         return DATA + f"nrel_efs/EFSLoadProfile_{efs_case}_{efs_speed}.csv"
     elif profile == "eer":
-        return DATA + "eer/demand_EER2025_100by2050.h5"
+        return DATA + f"eer/{eer_demand_file()}"
     elif profile == "ferc":
         return [
             DATA + "pudl/out_ferc714__hourly_estimated_state_demand.parquet",

--- a/workflow/rules/build_electricity.smk
+++ b/workflow/rules/build_electricity.smk
@@ -320,6 +320,8 @@ def demand_raw_data(wildcards):
             "efs_speed"
         ].capitalize()
         return DATA + f"nrel_efs/EFSLoadProfile_{efs_case}_{efs_speed}.csv"
+    elif profile == "eer":
+        return DATA + "eer/demand_EER2025_100by2050.h5"
     elif profile == "ferc":
         return [
             DATA + "pudl/out_ferc714__hourly_estimated_state_demand.parquet",
@@ -385,6 +387,8 @@ def demand_scaling_data(wildcards):
         return []
     elif profile == "ferc":
         return []
+    elif profile == "eer":
+        return []
     else:
         return ""
 
@@ -397,6 +401,7 @@ rule build_electrical_demand:
         eia_api=config["api"]["eia"],
         profile_year=pd.to_datetime(config["snapshots"]["start"]).year,
         planning_horizons=config["scenario"]["planning_horizons"],
+        renewable_weather_years=config["renewable_weather_years"],
         snapshots=config["snapshots"],
         pudl_path=config_provider("pudl_path"),
     input:

--- a/workflow/rules/retrieve.smk
+++ b/workflow/rules/retrieve.smk
@@ -88,6 +88,20 @@ rule retrieve_nrel_efs_data:
         "../scripts/retrieve_databundles.py"
 
 
+
+rule retrieve_eer_demand_data:
+    params:
+        url="https://zenodo.org/records/18435264/files/demand_EER2025_100by2050.h5?download=1",
+    output:
+        DATA + "eer/demand_EER2025_100by2050.h5",
+    resources:
+        mem_mb=5000,
+    log:
+        "logs/retrieve/retrieve_eer_demand_data.log",
+    script:
+        "../scripts/retrieve_eer_data.py"
+
+
 sector_datafiles = [
     # heating sector
     "population/DECENNIALDHC2020.P1-Data.csv",

--- a/workflow/rules/retrieve.smk
+++ b/workflow/rules/retrieve.smk
@@ -89,14 +89,16 @@ rule retrieve_nrel_efs_data:
 
 
 rule retrieve_eer_demand_data:
+    wildcard_constraints:
+        eer_file="demand_EER2025_100by2050|demand_EER2025_Baseline_AEO2023|demand_EER2025_IRAlow",
     params:
-        url="https://zenodo.org/records/18435264/files/demand_EER2025_100by2050.h5?download=1",
+        url=lambda wildcards: f"https://zenodo.org/records/18435264/files/{wildcards.eer_file}.h5?download=1",
     output:
-        DATA + "eer/demand_EER2025_100by2050.h5",
+        DATA + "eer/{eer_file}.h5",
     resources:
         mem_mb=5000,
     log:
-        "logs/retrieve/retrieve_eer_demand_data.log",
+        "logs/retrieve/retrieve_eer_{eer_file}.log",
     script:
         "../scripts/retrieve_eer_data.py"
 

--- a/workflow/rules/retrieve.smk
+++ b/workflow/rules/retrieve.smk
@@ -88,7 +88,6 @@ rule retrieve_nrel_efs_data:
         "../scripts/retrieve_databundles.py"
 
 
-
 rule retrieve_eer_demand_data:
     params:
         url="https://zenodo.org/records/18435264/files/demand_EER2025_100by2050.h5?download=1",

--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -496,7 +496,7 @@ class ReadEer(ReadStrategy):
         if invalid_years:
             raise ValueError(
                 f"EER demand supports planning_horizons {cls.MODEL_YEARS}; "
-                f"received unsupported year(s): {invalid_years}."
+                f"received unsupported year(s): {invalid_years}.",
             )
         return years
 
@@ -504,7 +504,7 @@ class ReadEer(ReadStrategy):
     def _validate_weather_year(cls, renewable_weather_years: list[int] | None) -> int:
         if not renewable_weather_years:
             raise ValueError(
-                "EER demand requires renewable_weather_years with exactly one weather year."
+                "EER demand requires renewable_weather_years with exactly one weather year.",
             )
 
         years = [int(year) for year in renewable_weather_years]
@@ -512,14 +512,13 @@ class ReadEer(ReadStrategy):
             raise ValueError(
                 "EER demand requires exactly one renewable_weather_years entry "
                 "because the electrical demand output path is not weather-year specific; "
-                f"received {years}."
+                f"received {years}.",
             )
 
         weather_year = years[0]
         if weather_year not in cls.WEATHER_YEARS:
             raise ValueError(
-                f"EER demand supports weather years {cls.WEATHER_YEARS}; "
-                f"received {weather_year}."
+                f"EER demand supports weather years {cls.WEATHER_YEARS}; received {weather_year}.",
             )
         return weather_year
 
@@ -544,7 +543,7 @@ class ReadEer(ReadStrategy):
                 group = h5.get_node(f"/{model_year}")
             except tables.NoSuchNodeError as exc:
                 raise ValueError(
-                    f"EER demand file does not contain model year {model_year}."
+                    f"EER demand file does not contain model year {model_year}.",
                 ) from exc
 
             state_codes = [

--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -444,6 +444,146 @@ class ReadEfs(ReadStrategy):
         return all_years
 
 
+class ReadEer(ReadStrategy):
+    """Reads state-level EER electricity demand profiles."""
+
+    MODEL_YEARS: ClassVar[tuple[int, ...]] = (2021, 2025, 2030, 2035, 2040, 2045, 2050)
+    WEATHER_YEARS: ClassVar[tuple[int, ...]] = (
+        2007,
+        2008,
+        2009,
+        2010,
+        2011,
+        2012,
+        2013,
+        2016,
+        2017,
+        2018,
+        2019,
+        2020,
+        2021,
+        2022,
+        2023,
+    )
+    HOURS_PER_YEAR: ClassVar[int] = 8760
+    CST_TO_UTC_SHIFT: ClassVar[int] = 6
+
+    def __init__(
+        self,
+        filepath: str | None = None,
+        planning_horizons: list[int] | None = None,
+        renewable_weather_years: list[int] | None = None,
+    ) -> None:
+        super().__init__(filepath)
+        self._zone = "state"
+        self.planning_horizons = self._validate_planning_horizons(planning_horizons)
+        self.weather_year = self._validate_weather_year(renewable_weather_years)
+
+    @property
+    def zone(self):  # noqa: D102
+        return self._zone
+
+    @classmethod
+    def _validate_planning_horizons(
+        cls,
+        planning_horizons: list[int] | None,
+    ) -> list[int]:
+        if not planning_horizons:
+            raise ValueError("EER demand requires scenario.planning_horizons.")
+
+        years = [int(year) for year in planning_horizons]
+        invalid_years = sorted(set(years) - set(cls.MODEL_YEARS))
+        if invalid_years:
+            raise ValueError(
+                f"EER demand supports planning_horizons {cls.MODEL_YEARS}; "
+                f"received unsupported year(s): {invalid_years}."
+            )
+        return years
+
+    @classmethod
+    def _validate_weather_year(cls, renewable_weather_years: list[int] | None) -> int:
+        if not renewable_weather_years:
+            raise ValueError(
+                "EER demand requires renewable_weather_years with exactly one weather year."
+            )
+
+        years = [int(year) for year in renewable_weather_years]
+        if len(years) != 1:
+            raise ValueError(
+                "EER demand requires exactly one renewable_weather_years entry "
+                "because the electrical demand output path is not weather-year specific; "
+                f"received {years}."
+            )
+
+        weather_year = years[0]
+        if weather_year not in cls.WEATHER_YEARS:
+            raise ValueError(
+                f"EER demand supports weather years {cls.WEATHER_YEARS}; "
+                f"received {weather_year}."
+            )
+        return weather_year
+
+    def _read_data(self) -> dict[int, pd.DataFrame]:
+        """Reads EER profiles for each requested model year."""
+        if not self.filepath:
+            logger.error("Must provide filepath for EER data")
+            sys.exit()
+
+        logger.info(f"Building Load Data using EER demand for weather year {self.weather_year}")
+        return {year: self._read_model_year(year) for year in self.planning_horizons}
+
+    def _read_model_year(self, model_year: int) -> pd.DataFrame:
+        """Read one model year and select the configured weather-year segment."""
+        import tables
+
+        start = self.WEATHER_YEARS.index(self.weather_year) * self.HOURS_PER_YEAR
+        stop = start + self.HOURS_PER_YEAR
+
+        with tables.open_file(self.filepath, "r") as h5:
+            try:
+                group = h5.get_node(f"/{model_year}")
+            except tables.NoSuchNodeError as exc:
+                raise ValueError(
+                    f"EER demand file does not contain model year {model_year}."
+                ) from exc
+
+            state_codes = [
+                self._decode_hdf_string(column)
+                for column in group.columns[:]
+                if self._decode_hdf_string(column) != "datetime"
+            ]
+            data = {
+                CODE_2_STATE[state]: np.roll(
+                    getattr(group, state)[start:stop],
+                    self.CST_TO_UTC_SHIFT,
+                )
+                for state in state_codes
+            }
+
+        snapshots = pd.date_range(
+            f"{model_year}-01-01 00:00:00",
+            periods=self.HOURS_PER_YEAR,
+            freq="h",
+        )
+        return pd.DataFrame(data, index=snapshots)
+
+    @staticmethod
+    def _decode_hdf_string(value) -> str:
+        if isinstance(value, bytes):
+            return value.decode()
+        return str(value)
+
+    def _format_data(self, data: dict[int, pd.DataFrame]) -> pd.DataFrame:
+        """Formats raw EER data to the demand strategy contract."""
+        df = pd.concat(data.values()).sort_index()
+        df = self._format_snapshot_index(df)
+        df["fuel"] = "electricity"
+        df["sector"] = "all"
+        df["subsector"] = "all"
+        df = df.set_index([df.index, "sector", "subsector", "fuel"])
+        return df
+
+
 class ReadEulp(ReadStrategy):
     """Reads in End Use Load Profile data."""
 
@@ -2216,10 +2356,13 @@ def get_demand_params(
                 scaling_method = "aeo_electricity"
             elif demand_profile == "ferc":
                 scaling_method = "aeo_electricity"
+            elif demand_profile == "eer":
+                scaling_method = None
             else:
                 logger.warning(
                     f"No scaling method available for {demand_profile} profile. Setting to 'aeo_electricity'",
                 )
+                scaling_method = "aeo_electricity"
         case "residential" | "commercial":
             demand_profile = "eulp"
             demand_disaggregation = "pop"
@@ -2391,6 +2534,14 @@ if __name__ == "__main__":
         sns = n.snapshots.get_level_values(1).map(
             lambda x: x.replace(year=profile_year),
         )
+
+    elif demand_profile == "eer":
+        reader = ReadEer(
+            demand_files,
+            planning_horizons=planning_horizons,
+            renewable_weather_years=snakemake.params.renewable_weather_years,
+        )
+        sns = n.snapshots.get_level_values(1)
 
     elif demand_profile == "ferc":
         assert profile_year in range(2018, 2024)

--- a/workflow/scripts/nrel_exclusion/__init__.py
+++ b/workflow/scripts/nrel_exclusion/__init__.py
@@ -1,0 +1,1 @@
+"""NREL exclusion helper scripts."""

--- a/workflow/scripts/nrel_exclusion/aggregate_godeeep_weighted.py
+++ b/workflow/scripts/nrel_exclusion/aggregate_godeeep_weighted.py
@@ -129,8 +129,8 @@ def weighted_bus_aggregation(
 
     buses = sorted(mapping["name"].unique())
     bus_idx = {b: i for i, b in enumerate(buses)}
-    B = len(buses)
-    T = cf.sizes["time"]
+    bus_count = len(buses)
+    time_count = cf.sizes["time"]
 
     # Precompute vectors aligned to mapping rows
     row_bus = mapping["name"].map(bus_idx).to_numpy(dtype=np.int64)
@@ -144,17 +144,17 @@ def weighted_bus_aggregation(
     row_w_k = row_w[keep]
 
     # Per-bus diagnostics (cheap, before streaming CF)
-    avail_sum = np.zeros(B, dtype=np.float64)
-    n_cells = np.zeros(B, dtype=np.int32)
+    avail_sum = np.zeros(bus_count, dtype=np.float64)
+    n_cells = np.zeros(bus_count, dtype=np.int32)
     np.add.at(avail_sum, row_bus, row_w)
     np.add.at(n_cells, row_bus, 1)
-    den = np.zeros(B, dtype=np.float64)
+    den = np.zeros(bus_count, dtype=np.float64)
     np.add.at(den, row_bus_k, row_w_k)
 
-    num = np.zeros((T, B), dtype=np.float64)  # ~8760*B*8 bytes ≈ 333 MB @ B=4751
+    num = np.zeros((time_count, bus_count), dtype=np.float64)  # ~8760*bus_count*8 bytes ≈ 333 MB @ B=4751
 
-    for t0 in range(0, T, chunk_t):
-        t1 = min(t0 + chunk_t, T)
+    for t0 in range(0, time_count, chunk_t):
+        t1 = min(t0 + chunk_t, time_count)
         chunk = cf.isel(time=slice(t0, t1)).values  # (t1-t0, NS, EW), forces decode of one slab
         # Gather CF at the (NS, EW) of each kept mapping row -> (t1-t0, n_kept)
         cf_rows = chunk[:, row_ns_k, row_ew_k]

--- a/workflow/scripts/nrel_exclusion/build_nrel_availability.py
+++ b/workflow/scripts/nrel_exclusion/build_nrel_availability.py
@@ -160,7 +160,7 @@ def _warp_mask_to_grid(
     # nodata metadata. CEC/BOEM both use nodata=0, but for us 0 IS real data
     # (= "excluded"). Pass an out-of-band sentinel for src_nodata so no pixel
     # is masked — every source 0 and 1 gets reprojected onto the dst grid.
-    OOB_SENTINEL = -9999.0
+    oob_sentinel = -9999.0
     dst = np.full(dst_shape, fill, dtype=np.float32)
     with rasterio.open(src_path) as src:
         src_arr = src.read(1).astype(np.float32)
@@ -172,7 +172,7 @@ def _warp_mask_to_grid(
             dst_transform=dst_transform,
             dst_crs=dst_crs,
             resampling=Resampling.nearest,
-            src_nodata=OOB_SENTINEL,
+            src_nodata=oob_sentinel,
             dst_nodata=fill,
             init_dest_nodata=False,
         )

--- a/workflow/scripts/nrel_exclusion/build_nrel_bus_capacities.py
+++ b/workflow/scripts/nrel_exclusion/build_nrel_bus_capacities.py
@@ -228,8 +228,10 @@ def rollup_supply_curve(
     # downstream code can .sel() a zero-row result without crashing.
     if joined.empty:
         print("[caps] no surviving sites — writing empty caps Dataset")
+
         def empty():
             return np.array([], dtype=np.float32)
+
         data_vars = {
             "p_nom_max": (("bus",), empty()),
             "potential": (("bus",), empty()),

--- a/workflow/scripts/nrel_exclusion/build_nrel_bus_capacities.py
+++ b/workflow/scripts/nrel_exclusion/build_nrel_bus_capacities.py
@@ -74,12 +74,12 @@ OFFSHORE_TECH_FILTER = {
 
 
 def haversine_km(lat1, lon1, lat2, lon2):
-    R = 6371.0
+    earth_radius_km = 6371.0
     lat1, lat2 = np.radians(lat1), np.radians(lat2)
     dlat = lat2 - lat1
     dlon = np.radians(lon2 - lon1)
     a = np.sin(dlat / 2) ** 2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2) ** 2
-    return 2 * R * np.arcsin(np.sqrt(a))
+    return 2 * earth_radius_km * np.arcsin(np.sqrt(a))
 
 
 def _sample_raster(path: str | Path, lon: np.ndarray, lat: np.ndarray) -> np.ndarray:
@@ -228,7 +228,8 @@ def rollup_supply_curve(
     # downstream code can .sel() a zero-row result without crashing.
     if joined.empty:
         print("[caps] no surviving sites — writing empty caps Dataset")
-        empty = lambda: np.array([], dtype=np.float32)
+        def empty():
+            return np.array([], dtype=np.float32)
         data_vars = {
             "p_nom_max": (("bus",), empty()),
             "potential": (("bus",), empty()),

--- a/workflow/scripts/nrel_exclusion/compress_godeeep.py
+++ b/workflow/scripts/nrel_exclusion/compress_godeeep.py
@@ -13,7 +13,7 @@ import os
 import time
 from pathlib import Path
 
-import netCDF4 as nc
+import netCDF4 as netcdf
 import numpy as np
 
 DEFAULT_CHUNK_T = 500  # hours per time chunk
@@ -27,7 +27,7 @@ def compress_one(src_path: str, out_path: str, chunk_t: int = DEFAULT_CHUNK_T) -
 
     Path(out_path).parent.mkdir(parents=True, exist_ok=True)
 
-    with nc.Dataset(src_path) as srcf, nc.Dataset(out_path, "w") as dstf:
+    with netcdf.Dataset(src_path) as srcf, netcdf.Dataset(out_path, "w") as dstf:
         # Copy dimensions with original names (keep "Time" so downstream code is unchanged)
         for name, dim in srcf.dimensions.items():
             dstf.createDimension(name, len(dim))
@@ -47,7 +47,7 @@ def compress_one(src_path: str, out_path: str, chunk_t: int = DEFAULT_CHUNK_T) -
                 dst_var.setncattr(attr, var.getncattr(attr))
 
         src_cf = srcf.variables["capacity_factor"]
-        T, NS, EW = src_cf.shape
+        time_count, ns_count, ew_count = src_cf.shape
 
         cfv = dstf.createVariable(
             "capacity_factor",
@@ -55,7 +55,7 @@ def compress_one(src_path: str, out_path: str, chunk_t: int = DEFAULT_CHUNK_T) -
             src_cf.dimensions,
             zlib=True,
             complevel=4,
-            chunksizes=(min(chunk_t, T), NS, EW),
+            chunksizes=(min(chunk_t, time_count), ns_count, ew_count),
             fill_value=FILL,
         )
         cfv.setncattr("scale_factor", SCALE)
@@ -68,8 +68,8 @@ def compress_one(src_path: str, out_path: str, chunk_t: int = DEFAULT_CHUNK_T) -
         cfv.set_auto_scale(False)
         cfv.set_auto_mask(False)
 
-        for t0 in range(0, T, chunk_t):
-            t1 = min(t0 + chunk_t, T)
+        for t0 in range(0, time_count, chunk_t):
+            t1 = min(t0 + chunk_t, time_count)
             chunk = src_cf[t0:t1, :, :]
             mask = np.isnan(chunk)
             quant = np.clip(np.round(chunk * 254.0), 0, 254).astype(np.uint8)

--- a/workflow/scripts/nrel_exclusion/compress_godeeep.py
+++ b/workflow/scripts/nrel_exclusion/compress_godeeep.py
@@ -13,7 +13,7 @@ import os
 import time
 from pathlib import Path
 
-import netCDF4 as netcdf
+import netCDF4
 import numpy as np
 
 DEFAULT_CHUNK_T = 500  # hours per time chunk
@@ -27,7 +27,7 @@ def compress_one(src_path: str, out_path: str, chunk_t: int = DEFAULT_CHUNK_T) -
 
     Path(out_path).parent.mkdir(parents=True, exist_ok=True)
 
-    with netcdf.Dataset(src_path) as srcf, netcdf.Dataset(out_path, "w") as dstf:
+    with netCDF4.Dataset(src_path) as srcf, netCDF4.Dataset(out_path, "w") as dstf:
         # Copy dimensions with original names (keep "Time" so downstream code is unchanged)
         for name, dim in srcf.dimensions.items():
             dstf.createDimension(name, len(dim))

--- a/workflow/scripts/opts/policy.py
+++ b/workflow/scripts/opts/policy.py
@@ -184,9 +184,9 @@ def add_technology_capacity_target_constraints(n, config):
             )
 
         if not np.isnan(target["max"]):
-            _RESIDUAL_TOL = 1.0  # MW — treat clustering residuals below this as zero
+            residual_tol = 1.0  # MW — treat clustering residuals below this as zero
             if target["max"] < lhs_existing:
-                if lhs_existing - target["max"] > _RESIDUAL_TOL:
+                if lhs_existing - target["max"] > residual_tol:
                     logger.warning(
                         f"TCT max of {target['max']} MW for {target['carrier']} in region {target['region']} "
                         f"is below existing non-extendable capacity of {lhs_existing:.1f} MW — "

--- a/workflow/scripts/opts/policy.py
+++ b/workflow/scripts/opts/policy.py
@@ -195,7 +195,7 @@ def add_technology_capacity_target_constraints(n, config):
                 else:
                     logger.warning(
                         f"TCT max of {target['max']} MW for {target['carrier']} is below existing "
-                        f"{lhs_existing:.4f} MW (within {_RESIDUAL_TOL} MW tolerance — treating as numerical residual)",
+                        f"{lhs_existing:.4f} MW (within {residual_tol} MW tolerance — treating as numerical residual)",
                     )
                 lhs_existing = target["max"]  # clamp so rhs = 0 in both cases
 

--- a/workflow/scripts/retrieve_eer_data.py
+++ b/workflow/scripts/retrieve_eer_data.py
@@ -1,0 +1,24 @@
+"""Retrieve EER electricity demand profiles."""
+
+import logging
+from pathlib import Path
+
+from _helpers import configure_logging, progress_retrieve
+
+logger = logging.getLogger(__name__)
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake("retrieve_eer_demand_data")
+
+    configure_logging(snakemake)
+
+    output = Path(snakemake.output[0])
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    url = snakemake.params.url
+    logger.info(f"Downloading EER demand data from '{url}'.")
+    progress_retrieve(url, output)

--- a/workflow/scripts/retrieve_nrel_exclusion.py
+++ b/workflow/scripts/retrieve_nrel_exclusion.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from zenodo_downloader import ZenodoScenarioDownloader
 
 if __name__ == "__main__":
-    out_path = Path(snakemake.output[0])
+    out_path = Path(snakemake.output[0])  # noqa: F821
     filename = out_path.name
 
     downloader = ZenodoScenarioDownloader()

--- a/workflow/scripts/test/test_build_demand_eer.py
+++ b/workflow/scripts/test/test_build_demand_eer.py
@@ -1,3 +1,5 @@
+"""Tests for EER demand profile loading."""
+
 import numpy as np
 import pandas as pd
 import pytest

--- a/workflow/scripts/test/test_build_demand_eer.py
+++ b/workflow/scripts/test/test_build_demand_eer.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import tables
-
 from build_demand import ReadEer
 
 

--- a/workflow/scripts/test/test_build_demand_eer.py
+++ b/workflow/scripts/test/test_build_demand_eer.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pandas as pd
+import pytest
+import tables
+
+from build_demand import ReadEer
+
+
+def _write_eer_fixture(path, model_year=2030):
+    hours = ReadEer.HOURS_PER_YEAR
+    total_hours = hours * len(ReadEer.WEATHER_YEARS)
+
+    with tables.open_file(path, "w") as h5:
+        group = h5.create_group("/", str(model_year))
+        h5.create_array(
+            group,
+            "columns",
+            np.array([b"datetime", b"AL", b"CA"]),
+        )
+        h5.create_carray(
+            group,
+            "datetime",
+            tables.StringAtom(itemsize=30),
+            shape=(total_hours,),
+        )
+        for state, offset in {"AL": 0, "CA": 1000000}.items():
+            values = np.arange(offset, offset + total_hours, dtype=np.int32)
+            node = h5.create_carray(
+                group,
+                state,
+                tables.Int32Atom(),
+                shape=(total_hours,),
+            )
+            node[:] = values
+
+
+def test_read_eer_selects_model_and_weather_year_with_cst_shift(tmp_path):
+    path = tmp_path / "eer.h5"
+    _write_eer_fixture(path, model_year=2030)
+
+    reader = ReadEer(
+        str(path),
+        planning_horizons=[2030],
+        renewable_weather_years=[2010],
+    )
+    demand = reader.read_demand()
+
+    weather_start = ReadEer.WEATHER_YEARS.index(2010) * ReadEer.HOURS_PER_YEAR
+    first_snapshot = pd.Timestamp("2030-01-01 00:00:00")
+    sixth_snapshot = pd.Timestamp("2030-01-01 06:00:00")
+
+    assert len(demand) == ReadEer.HOURS_PER_YEAR
+    assert demand.index.names == ["snapshot", "sector", "subsector", "fuel"]
+    assert "Alabama" in demand.columns
+    assert "California" in demand.columns
+    assert demand.loc[(first_snapshot, "all", "all", "electricity"), "Alabama"] == (
+        weather_start + ReadEer.HOURS_PER_YEAR - ReadEer.CST_TO_UTC_SHIFT
+    )
+    assert demand.loc[(sixth_snapshot, "all", "all", "electricity"), "Alabama"] == weather_start
+
+
+def test_read_eer_rejects_invalid_weather_year(tmp_path):
+    with pytest.raises(ValueError, match="supports weather years"):
+        ReadEer(str(tmp_path / "eer.h5"), planning_horizons=[2030], renewable_weather_years=[2014])
+
+
+def test_read_eer_rejects_multiple_weather_years(tmp_path):
+    with pytest.raises(ValueError, match="exactly one"):
+        ReadEer(str(tmp_path / "eer.h5"), planning_horizons=[2030], renewable_weather_years=[2010, 2011])
+
+
+def test_read_eer_rejects_unsupported_planning_horizon(tmp_path):
+    with pytest.raises(ValueError, match="unsupported year"):
+        ReadEer(str(tmp_path / "eer.h5"), planning_horizons=[2032], renewable_weather_years=[2010])


### PR DESCRIPTION
Closes #756.

## Changes proposed in this Pull Request
- Add `electricity.demand.profile: eer` for power-demand builds.
- Retrieve the selected EER HDF5 demand dataset from Zenodo: https://zenodo.org/records/18435264.
- Add `electricity.demand.scenario.eer_file` to select one of:
  - `demand_EER2025_100by2050.h5`
  - `demand_EER2025_Baseline_AEO2023.h5`
  - `demand_EER2025_IRAlow.h5`
- Read state-level EER demand with the existing population-based state-to-bus disaggregation path and no AEO/EFS scaling.
- Validate EER configuration limits:
  - `scenario.planning_horizons` must use supported EER model years: `2021, 2025, 2030, 2035, 2040, 2045, 2050`.
  - `renewable_weather_years` must contain exactly one supported EER weather year: `2007-2013` or `2016-2023`.
- Align EER hourly CST (UTC-06:00) profiles to the existing naive UTC-style demand snapshot convention.

Validation performed:
- `python -m py_compile workflow/scripts/build_demand.py workflow/scripts/retrieve_eer_data.py workflow/scripts/test/test_build_demand_eer.py`
- `C:\Users\23963\anaconda3\envs\pypsa-usa\python.exe -m pytest -q workflow/scripts/test/test_build_demand_eer.py`
- Snakemake dry-run for all three EER retrieve targets:
  - `data/eer/demand_EER2025_100by2050.h5`
  - `data/eer/demand_EER2025_Baseline_AEO2023.h5`
  - `data/eer/demand_EER2025_IRAlow.h5`
- Snakemake dry-run for `resources/Default/usa/demand/power_electricity.csv` with local `electricity.demand.profile: eer`, confirming the configured EER file feeds `build_electrical_demand`.

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in all of `config.default.yaml`.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`.