### PR TITLE
Correct StorageUnit max_hours for storage duration

### DIFF
--- a/workflow/scripts/add_electricity.py
+++ b/workflow/scripts/add_electricity.py
@@ -856,7 +856,7 @@ def attach_battery_storage(
         p_nom_min=0,
         p_nom_extendable=False,  # Only Allow lifetime retirments for existing BESS
         capital_cost=costs.at["4hr_battery_storage", "opex_fixed_per_kw"] * 1e3,
-        max_hours=plants_filt.energy_storage_capacity_mwh / plants_filt.p_nom,
+        max_hours=plants_filt.energy_storage_capacity_mwh / plants_filt.p_nom / 0.85**0.5,
         build_year=plants_filt.build_year,
         lifetime=costs.at["4hr_battery_storage", "lifetime"],
         efficiency_store=0.85**0.5,

--- a/workflow/scripts/add_extra_components.py
+++ b/workflow/scripts/add_extra_components.py
@@ -79,8 +79,8 @@ def attach_storageunits(n, costs, elec_opts, investment_year):
             marginal_cost=0,  # costs.at[carrier, "marginal_cost"], # TODO: FIX THIS ISSUE IN BUILD_COST_DATA
             efficiency_store=costs.at[carrier, "efficiency"] ** roundtrip_correction,
             efficiency_dispatch=costs.at[carrier, "efficiency"] ** roundtrip_correction,
-            max_hours=max_hours,
-            cyclic_state_of_charge=False,
+            max_hours=max_hours / (costs.at[carrier, "efficiency"] ** roundtrip_correction),
+            cyclic_state_of_charge=True,
             build_year=investment_year,
             lifetime=costs.at[carrier, "cost_recovery_period_years"],
         )
@@ -178,7 +178,7 @@ def attach_phs_storageunits(n: pypsa.Network, elec_opts, costs: pd.DataFrame):
             marginal_cost=region_onshore_psh_grp.marginal_cost,
             efficiency_store=efficiency_store,
             efficiency_dispatch=efficiency_dispatch,
-            max_hours=max_hours,
+            max_hours=max_hours / efficiency_dispatch,
             cyclic_state_of_charge=True,
         )
 


### PR DESCRIPTION
Closes #760.

## Changes proposed in this Pull Request

- Correct existing BESS `max_hours` by accounting for the 85% round-trip efficiency split on dispatch.
- Correct configured battery storage `max_hours` so an x-hour duration can deliver rated `p_nom` for x hours after dispatch losses.
- Keep configured battery storage units cyclic when applying the duration correction.
- Correct existing PHS `max_hours` to use the parsed duration divided by `efficiency_dispatch`.


## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`. N/A, no dependency changes.
- [x] Changes in configuration options are added in all of `config.default.yaml`. N/A, no configuration changes.
- [x] Changes in configuration options are also documented in `doc/configtables/*.csv`. N/A, no configuration changes.
