### PR TITLE
Use shared constant for hours per year

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -11,6 +11,7 @@ path = workflow.source_path("../scripts/_helpers.py")
 sys.path.insert(0, os.path.dirname(path))
 
 from _helpers import validate_checksum, update_config_from_wildcards
+from constants import HOURS_PER_YEAR
 from snakemake.utils import update_config
 
 
@@ -95,7 +96,7 @@ def memory(w):
     for o in w.opts.split("-"):
         m = re.match(r"^(\d+)seg$", o, re.IGNORECASE)
         if m is not None:
-            factor *= int(m.group(1)) / 8760
+            factor *= int(m.group(1)) / HOURS_PER_YEAR
             break
     if w.clusters.endswith("m") or w.clusters.endswith("c"):
         val = int(factor * (50000 + 30 * int(w.simpl) + 195 * int(w.clusters[:-1])))

--- a/workflow/scripts/_helpers.py
+++ b/workflow/scripts/_helpers.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pypsa
 import requests
 import yaml
+from constants import HOURS_PER_YEAR
 from snakemake.utils import update_config
 
 REGION_COLS = ["geometry", "name", "x", "y", "country"]
@@ -221,7 +222,7 @@ def load_network_for_plots(fn, tech_costs, config, combine_hydro_ps=True):
     # bus_carrier = n.storage_units.bus.map(n.buses.carrier)
     # n.storage_units.loc[bus_carrier == "heat","carrier"] = "water tanks"
 
-    num_years = n.snapshot_weightings.loc[n.investment_periods[0]].objective.sum() / 8760.0
+    num_years = n.snapshot_weightings.loc[n.investment_periods[0]].objective.sum() / HOURS_PER_YEAR
     costs = load_costs(tech_costs, config["costs"], config["electricity"], num_years)
     update_transmission_costs(n, costs)
 

--- a/workflow/scripts/add_extra_components.py
+++ b/workflow/scripts/add_extra_components.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pypsa
 from _helpers import calculate_annuity, configure_logging, load_costs
 from add_electricity import add_missing_carriers
+from constants import HOURS_PER_YEAR
 from eia import FuelCosts
 from opts._helpers import get_region_buses
 from pypsa.descriptors import get_switchable_as_dense as get_as_dense
@@ -154,7 +155,7 @@ def attach_phs_storageunits(n: pypsa.Network, elec_opts, costs: pd.DataFrame):
             * region_onshore_psh_grp["cost_kw_round"]
             * 1e3
             * n.snapshot_weightings.objective.sum()
-            / 8760.0
+            / HOURS_PER_YEAR
         )
 
         region_onshore_psh_grp["marginal_cost"] = psh_vom
@@ -1342,7 +1343,7 @@ def add_co2_network(n: pypsa.Network, config: dict):
         connections = n.lines
 
     # calculate annualized capital cost
-    number_years = n.snapshot_weightings.generators.sum() / 8760
+    number_years = n.snapshot_weightings.generators.sum() / HOURS_PER_YEAR
     cost = (
         config["co2"]["network"]["capital_cost"]
         * calculate_annuity(config["co2"]["network"]["lifetime"], config["co2"]["network"]["discount_rate"])
@@ -1507,7 +1508,7 @@ def add_dac(n: pypsa.Network, config: dict, sector: bool):
     )
 
     # calculate annualized capital cost
-    number_years = n.snapshot_weightings.generators.sum() / 8760
+    number_years = n.snapshot_weightings.generators.sum() / HOURS_PER_YEAR
     cost = (
         config["dac"]["capital_cost"]
         * calculate_annuity(config["dac"]["lifetime"], config["dac"]["discount_rate"])

--- a/workflow/scripts/build_cost_data.py
+++ b/workflow/scripts/build_cost_data.py
@@ -166,7 +166,7 @@ def get_sector_costs(
         capex = capex.value.unstack().fillna(0)
 
         # n years should be
-        # n.snapshot_weightings.loc[n.investment_periods[x]].objective.sum() / 8760.0
+        # n.snapshot_weightings.loc[n.investment_periods[x]].objective.sum() / const.HOURS_PER_YEAR
 
         capex["capital_cost"] = (
             (

--- a/workflow/scripts/build_demand.py
+++ b/workflow/scripts/build_demand.py
@@ -382,7 +382,7 @@ class ReadEfs(ReadStrategy):
 
         df["utc_shift"] = df.State.map(utc_shift)
         df["UtcHourID"] = df.LocalHourID + df.utc_shift
-        df["UtcHourID"] = df.UtcHourID.map(lambda x: x if x < 8761 else x - 8760)
+        df["UtcHourID"] = df.UtcHourID.map(lambda x: x if x < const.HOURS_PER_YEAR + 1 else x - const.HOURS_PER_YEAR)
         df = df.drop(columns=["utc_shift"])
         return df
 
@@ -465,7 +465,7 @@ class ReadEer(ReadStrategy):
         2022,
         2023,
     )
-    HOURS_PER_YEAR: ClassVar[int] = 8760
+    HOURS_PER_YEAR: ClassVar[int] = const.HOURS_PER_YEAR
     CST_TO_UTC_SHIFT: ClassVar[int] = 6
 
     def __init__(
@@ -636,7 +636,7 @@ class ReadEulp(ReadStrategy):
             aggfunc="sum",
         )
         df = df.rename(columns=CODE_2_STATE)
-        assert len(df.index.get_level_values("snapshot").unique()) == 8760
+        assert len(df.index.get_level_values("snapshot").unique()) == const.HOURS_PER_YEAR
         assert not df.empty
         return df
 
@@ -819,7 +819,7 @@ class ReadCliu(ReadStrategy):
         """
         Applies profile data to annual demand data.
 
-        This is quite a heavy operation, as it can be up to 8760hrs,
+        This is quite a heavy operation, as it can be up to a full year of hourly records,
         3000+ counties, 50+ subsectors and 4 fuels.
         """
 
@@ -1555,7 +1555,7 @@ class ReadTransportAeo(ReadStrategy):
 
             df = df.div(100)  # convert from percentage to decimal
             df = df.mul(demand_national.loc[(self.vehicle, year), "value"])
-            df = df.mul(1 / 8760)  # uniform load over the year
+            df = df.mul(1 / const.HOURS_PER_YEAR)  # uniform load over the year
 
             dfs.append(df)
 

--- a/workflow/scripts/constants.py
+++ b/workflow/scripts/constants.py
@@ -17,6 +17,9 @@ GPS_CRS = "EPSG:4326"
 # convert euros to USD
 EUR_2_USD = 1.07  # taken on 12-12-2023
 
+# number of hours in a non-leap year
+HOURS_PER_YEAR = 8760
+
 # energy content of natural gas
 # Assumes national averages for the conversion
 # https://www.eia.gov/naturalgas/monthly/pdf/table_25.pdf

--- a/workflow/scripts/eulp.py
+++ b/workflow/scripts/eulp.py
@@ -222,7 +222,7 @@ class Eulp:
             df.index = pd.to_datetime(df.index)
         df.index = df.index.map(lambda x: x.replace(year=2018))
         resampled = df.resample("1h").sum()
-        assert len(resampled == 8760), "Length of resampled != 8760 :("
+        assert len(resampled) == 8760, "Length of resampled != 8760 :("
         return resampled.sort_index()
 
     def _aggregate_data(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -344,7 +344,7 @@ class EulpTotals:
             df.index = pd.to_datetime(df.index)
         df.index = df.index.map(lambda x: x.replace(year=2018))
         resampled = df.resample("1h").sum()
-        assert len(resampled == 8760), "Length of resampled != 8760 :("
+        assert len(resampled) == 8760, "Length of resampled != 8760 :("
         return resampled.sort_index()
 
     def _aggregate_data(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/workflow/scripts/prepare_network.py
+++ b/workflow/scripts/prepare_network.py
@@ -23,6 +23,7 @@ from _helpers import (
     set_scenario_config,
     update_config_from_wildcards,
 )
+from constants import HOURS_PER_YEAR
 
 idx = pd.IndexSlice
 
@@ -288,7 +289,7 @@ if __name__ == "__main__":
     transport_model = is_transport_model(params.transmission_network)
 
     n = pypsa.Network(snakemake.input[0])
-    num_years = n.snapshot_weightings.loc[n.investment_periods[0]].objective.sum() / 8760.0
+    num_years = n.snapshot_weightings.loc[n.investment_periods[0]].objective.sum() / HOURS_PER_YEAR
     costs = load_costs(snakemake.input.tech_costs, params.costs)
     # Set Investment Period Year Weightings
     # 'fillna(1)' needed if only one period

--- a/workflow/scripts/solve_network.py
+++ b/workflow/scripts/solve_network.py
@@ -33,6 +33,7 @@ from _helpers import (
     configure_logging,
     update_config_from_wildcards,
 )
+from constants import HOURS_PER_YEAR
 from opts.bidirectional_link import add_bidirectional_link_constraints
 from opts.interchange import add_interchange_constraints
 from opts.land import add_land_use_constraints
@@ -124,7 +125,7 @@ def prepare_network(n, solve_opts=None):
             names=n.snapshots.names,
         )
         n.set_snapshots(first_nhours)
-        n.snapshot_weightings[:] = 8760.0 / nhours
+        n.snapshot_weightings[:] = HOURS_PER_YEAR / nhours
 
     return n
 

--- a/workflow/scripts/test/test_constants.py
+++ b/workflow/scripts/test/test_constants.py
@@ -1,0 +1,35 @@
+"""Tests for shared constant usage."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EULP_PATH = REPO_ROOT / "workflow/scripts/eulp.py"
+
+
+def test_eulp_resampling_keeps_dataset_specific_2018_hour_count():
+    """EULP resampling is tied to 2018 data and should keep explicit hour checks."""
+    source = EULP_PATH.read_text()
+
+    assert source.count("assert len(resampled) == 8760") == 2
+
+
+def test_hours_per_year_uses_shared_constant():
+    """Avoid reintroducing bare 8760 literals in workflow source."""
+    source_files = [
+        *REPO_ROOT.glob("workflow/scripts/**/*.py"),
+        *REPO_ROOT.glob("workflow/rules/**/*.smk"),
+    ]
+
+    offenders = []
+    for path in source_files:
+        if path.name == "constants.py" or path == EULP_PATH or "/test/" in path.as_posix():
+            continue
+
+        for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+            code = line.split("#", maxsplit=1)[0]
+            if "8760" in code:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{line_number}: {line.strip()}")
+
+    assert not offenders, "Use the shared HOURS_PER_YEAR constant instead of bare 8760 literals:\n" + "\n".join(
+        offenders,
+    )


### PR DESCRIPTION
## Summary
- add `HOURS_PER_YEAR` to the shared workflow constants
- replace bare `8760`/`8760.0` year-hour literals in workflow scripts and rules
- add a static regression test to prevent reintroducing bare year-hour literals

Closes #763.

## Verification
- `python3 -m py_compile workflow/scripts/constants.py workflow/scripts/eulp.py workflow/scripts/add_extra_components.py workflow/scripts/_helpers.py workflow/scripts/prepare_network.py workflow/scripts/solve_network.py workflow/scripts/build_demand.py workflow/scripts/build_cost_data.py workflow/scripts/test/test_constants.py`
- `uvx ruff check workflow/scripts/constants.py workflow/scripts/eulp.py workflow/scripts/add_extra_components.py workflow/scripts/_helpers.py workflow/scripts/prepare_network.py workflow/scripts/solve_network.py workflow/scripts/build_demand.py workflow/scripts/build_cost_data.py workflow/scripts/test/test_constants.py`
- `uvx --from pytest pytest --noconftest workflow/scripts/test/test_constants.py -q`

Note: I attempted the project-managed pytest run with `uv run --extra dev pytest workflow/scripts/test/test_constants.py -q`, but local dependency sync failed while building `datrie==0.8.2` from Snakemake on this machine before tests could start. The isolated static test above avoids the heavyweight model dependencies and passes.
