### PR TITLE
Fix URL in efs_databundle function

### DIFF
--- a/workflow/rules/retrieve.smk
+++ b/workflow/rules/retrieve.smk
@@ -68,7 +68,7 @@ rule retrieve_seismic_risk_mask:
 
 def efs_databundle(wildcards):
     return {
-        "EFS": f"https://data.nrel.gov/system/files/126/EFSLoadProfile_{wildcards.efs_case}_{wildcards.efs_speed}.zip"
+        "EFS": f"https://data.nlr.gov/system/files/126/EFSLoadProfile_{wildcards.efs_case}_{wildcards.efs_speed}.zip"
     }
 
 


### PR DESCRIPTION
Update EFS data retrieval URL from nrel.gov to nlr.gov

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
