### PR TITLE
Add two recent preprints to publications page 

### DIFF
--- a/docs/source/publications.bib
+++ b/docs/source/publications.bib
@@ -1,4 +1,22 @@
-@article{barnes_2026,
+@misc{barnes2026b,
+  title = {Near-Term Emission Targets Need Immediate Attention in the USA},
+  author = {Trevor Barnes and Kamran Tehranchi and Brad Reinholz and Malcolm Metcalfe and Taco Niet},
+  year = {2026},
+  archivePrefix = {arXiv},
+  url = {https://arxiv.org/abs/2607.01471},
+  doi = {10.48550/arXiv.2607.01471},
+}
+
+@misc{ai2026,
+  title = {Economic Valuation and Optimal Deployment of Static Synchronous Series Compensators for U.S. Power System Expansion},
+  author = {Wei Ai and Vladimir Dvorkin and Michael T. Craig},
+  year = {2026},
+  archivePrefix = {arXiv},
+  url = {https://arxiv.org/abs/2605.00734},
+  doi = {10.48550/arXiv.2605.00734},
+}
+
+@article{barnes_2026a,
     doi = {10.1371/journal.pclm.0000918},
     url = {https://journals.plos.org/climate/article?id=10.1371/journal.pclm.0000918},
     author = {Barnes, Trevor and Tehranchi, Kamran and Reinholz, Bradley and Metcalfe, Malcolm and Niet, Taco},


### PR DESCRIPTION
Adds the preprints for: 
- [Near-Term Emission Targets Need Immediate Attention in the USA](https://arxiv.org/abs/2607.01471) (July 2026) 
- [Economic Valuation and Optimal Deployment of Static Synchronous Series Compensators for U.S. Power System Expansion](https://arxiv.org/abs/2605.00734) (May 2026)